### PR TITLE
input: make maximum chunk size configurable

### DIFF
--- a/CHUNKS.md
+++ b/CHUNKS.md
@@ -21,6 +21,36 @@ For reliability and flexibility reasons, an input plugin might specify that all
 Chunks associated to it will be only located in memory, others might enable
 ```storage.type filesystem``` so the Chunk will be located also in filesystem.
 
+## Chunk size
+
+Input chunks have a soft maximum size of approximately 2 MB by default. Once a
+chunk crosses this threshold it is closed for further writes, but the write that
+crosses the threshold is not split and can make the final chunk larger.
+
+Advanced users can change the threshold for an individual input with
+`storage.max_chunk_size`. Larger chunks can reduce the number of output requests
+at the cost of higher memory use, flush latency, retry payload size, and coarser
+storage accounting. For example, a tail input feeding Azure Logs Ingestion can
+batch up to approximately 10 MB of uncompressed MessagePack data per chunk:
+
+```yaml
+pipeline:
+  inputs:
+    - name: tail
+      path: /var/log/containers/*.log
+      tag: azure.logs
+      storage.max_chunk_size: 10M
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure.logs
+      compress: on
+      # Azure connection settings omitted.
+```
+
+The compressed HTTP payload size depends on the records being sent.
+`storage.max_chunk_size` does not enforce a compressed output size.
+
 ## Chunk I/O: Low level
 
 In the low level side, all the Chunks management magic happens on a thin library called

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -308,6 +308,9 @@ struct flb_input_instance {
     /* Type of storage: CIO_STORE_FS (filesystem) or CIO_STORE_MEM (memory) */
     int storage_type;
 
+    /* Soft limit used to close chunks for further writes */
+    size_t storage_max_chunk_size;
+
     /*
      * Buffers counter: it counts the total of memory used by fixed and dynamic
      * message pack buffers used by the input plugin instance.

--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -37,8 +37,9 @@ struct cio_chunk;
  */
 #define FLB_INPUT_CHUNK_SIZE           262144  /* 256KB (hint) */
 /*
- * Defines a maximum size for a Chunk in the file system: note that despite
- * this is considered a limit, a Chunk size might get greater than this.
+ * Defines the default maximum size for a Chunk in the file system: note that
+ * despite this is considered a limit, a Chunk size might get greater than
+ * this.
  */
 #define FLB_INPUT_CHUNK_FS_MAX_SIZE   2048000  /* 2MB */
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -180,6 +180,12 @@ struct flb_config_map input_global_properties[] = {
         "Sets the storage type for this input, one of: filesystem, memory or memrb."
     },
     {
+        FLB_CONFIG_MAP_SIZE, "storage.max_chunk_size", STR(FLB_INPUT_CHUNK_FS_MAX_SIZE),
+        0, FLB_FALSE, 0,
+        "Set the soft maximum size for input chunks. A chunk may exceed this value by the "
+        "size of the write that crosses the limit."
+    },
+    {
         FLB_CONFIG_MAP_BOOL, "storage.pause_on_chunks_overlimit", "false",
         0, FLB_FALSE, 0,
         "Enable pausing on an input when they reach their chunks limit"
@@ -660,6 +666,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->mem_buf_status = FLB_INPUT_RUNNING;
         instance->mem_buf_limit = 0;
         instance->mem_chunks_size = 0;
+        instance->storage_max_chunk_size = FLB_INPUT_CHUNK_FS_MAX_SIZE;
 #ifdef FLB_HAVE_METRICS
         instance->rate_window_size = FLB_NSEC_IN_SEC;
         instance->rate_gate_enabled = FLB_FALSE;
@@ -986,6 +993,15 @@ int flb_input_set_property(struct flb_input_instance *ins,
         }
         flb_sds_destroy(tmp);
 
+    }
+    else if (prop_key_check("storage.max_chunk_size", k, len) == 0 && tmp) {
+        limit = flb_utils_size_to_bytes(tmp);
+        flb_sds_destroy(tmp);
+        if (limit <= 0) {
+            flb_error("[input] storage.max_chunk_size must be greater than zero");
+            return -1;
+        }
+        ins->storage_max_chunk_size = (size_t) limit;
     }
     else if (prop_key_check("threaded", k, len) == 0 && tmp) {
         enabled = flb_utils_bool(tmp);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -3388,8 +3388,8 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
         real_diff = 0;
     }
 
-    /* Lock buffers where size > 2MB */
-    if (content_size > FLB_INPUT_CHUNK_FS_MAX_SIZE) {
+    /* Lock buffers that have crossed the configured soft size limit */
+    if (content_size > in->storage_max_chunk_size) {
         cio_chunk_lock(ic->chunk);
     }
 
@@ -3456,8 +3456,9 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
             content_size = cio_chunk_get_content_size(ic->chunk);
 
             /* Do we have less than 1% available ? */
-            min = (FLB_INPUT_CHUNK_FS_MAX_SIZE * 0.01);
-            if (FLB_INPUT_CHUNK_FS_MAX_SIZE - content_size < min) {
+            min = (in->storage_max_chunk_size * 0.01);
+            if (content_size >= in->storage_max_chunk_size ||
+                in->storage_max_chunk_size - content_size < min) {
                 cio_chunk_down(ic->chunk);
             }
         }

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_tail_chunk_size.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_tail_chunk_size.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 5
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: azure_logs_ingestion
+      path: ${AZURE_LOGS_INGESTION_TAIL_PATH}
+      read_from_head: true
+      storage.max_chunk_size: 10M
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure_logs_ingestion
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -15,20 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 class Service:
-    def __init__(self, config_file):
+    def __init__(self, config_file, *, extra_env=None):
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
         cert_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate"))
         self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
         self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
         self.oauth_server_port = None
+        service_env = {
+            "CERTIFICATE_TEST": self.tls_crt_file,
+            "PRIVATE_KEY_TEST": self.tls_key_file,
+        }
+        service_env.update(extra_env or {})
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
             data_keys=["payloads", "requests"],
-            extra_env={
-                "CERTIFICATE_TEST": self.tls_crt_file,
-                "PRIVATE_KEY_TEST": self.tls_key_file,
-            },
+            extra_env=service_env,
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
         )
@@ -154,3 +156,43 @@ def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
     assert payload[0]["source"] == "dummy"
     assert payload[0]["level"] == "info"
     assert isinstance(payload[0]["@timestamp"], (int, float))
+
+
+def test_out_azure_logs_ingestion_tail_uses_configured_chunk_size(tmp_path):
+    record_count = 768
+    record_length = 8192
+    tail_path = tmp_path / "azure-logs-ingestion.log"
+
+    with tail_path.open("w", encoding="utf-8") as stream:
+        for index in range(record_count):
+            prefix = f"record-{index:04d}-"
+            stream.write(prefix + ("x" * (record_length - len(prefix))) + "\n")
+
+    assert 2_048_000 < tail_path.stat().st_size < 10_000_000
+
+    service = Service(
+        "out_azure_logs_ingestion_tail_chunk_size.yaml",
+        extra_env={"AZURE_LOGS_INGESTION_TAIL_PATH": tail_path},
+    )
+    service.start()
+    configure_http_response(status_code=200, body={"status": "received"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    requests_seen = service.wait_for_requests(2, timeout=20)
+    service.stop()
+
+    data_requests = [
+        request
+        for request in requests_seen
+        if request["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
+    ]
+    assert len(data_requests) == 1
+
+    data_request = data_requests[0]
+    assert data_request["headers"].get("Content-Encoding") == "gzip"
+    assert len(data_request["json"]) == record_count
+    assert data_request["json"][0]["log"].startswith("record-0000-")
+    assert data_request["json"][-1]["log"].startswith(f"record-{record_count - 1:04d}-")

--- a/tests/internal/fuzzers/input_fuzzer.c
+++ b/tests/internal/fuzzers/input_fuzzer.c
@@ -35,6 +35,7 @@ const char *input_chunk_property_keywords[] = {
     "tls.key_passwd",
     "threaded",
     "storage.type",
+    "storage.max_chunk_size",
 };
 
 int LLVMFuzzerTestOneInput(const uint8_t *data3, size_t size3)

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -502,6 +502,132 @@ static int log_cb(struct cio_ctx *data, int level, const char *file, int line,
     return 0;
 }
 
+void flb_test_input_chunk_configurable_max_size(void)
+{
+    int ret;
+    struct flb_input_instance *i_ins;
+    struct flb_output_instance *o_ins;
+    struct flb_input_chunk *first_chunk;
+    struct flb_input_chunk *second_chunk;
+    struct flb_input_chunk *ic;
+    struct flb_config *cfg;
+    struct cio_ctx *cio;
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct mk_event_loop *evl;
+    struct cio_options opts = {0};
+    msgpack_sbuffer mp_sbuf;
+    char payload[600];
+    char *root_path;
+
+    root_path = flb_test_tmpdir_cat("/input-chunk-configurable-max-size");
+    TEST_CHECK(root_path != NULL);
+    if (!root_path) {
+        return;
+    }
+
+    flb_init_env();
+    cfg = flb_config_init();
+    evl = mk_event_loop_create(256);
+    TEST_CHECK(evl != NULL);
+    if (!evl) {
+        flb_config_exit(cfg);
+        flb_free(root_path);
+        return;
+    }
+    cfg->evl = evl;
+
+    flb_log_create(cfg, FLB_LOG_STDERR, FLB_LOG_DEBUG, NULL);
+
+    i_ins = flb_input_new(cfg, "dummy", NULL, FLB_TRUE);
+    TEST_CHECK(i_ins != NULL);
+    if (!i_ins) {
+        flb_config_exit(cfg);
+        flb_free(root_path);
+        return;
+    }
+
+    TEST_CHECK(i_ins->storage_max_chunk_size == FLB_INPUT_CHUNK_FS_MAX_SIZE);
+    TEST_CHECK(flb_input_set_property(i_ins, "storage.max_chunk_size", "invalid") == -1);
+    TEST_CHECK(i_ins->storage_max_chunk_size == FLB_INPUT_CHUNK_FS_MAX_SIZE);
+    TEST_CHECK(flb_input_set_property(i_ins, "storage.max_chunk_size", "0") == -1);
+    TEST_CHECK(i_ins->storage_max_chunk_size == FLB_INPUT_CHUNK_FS_MAX_SIZE);
+    TEST_CHECK(flb_input_set_property(i_ins, "storage.max_chunk_size", "1K") == 0);
+    TEST_CHECK(i_ins->storage_max_chunk_size == 1000);
+    i_ins->storage_type = CIO_STORE_FS;
+
+    cio_options_init(&opts);
+    opts.root_path = root_path;
+    opts.log_cb = log_cb;
+    opts.log_level = CIO_LOG_DEBUG;
+    opts.flags = CIO_OPEN;
+
+    cio = cio_create(&opts);
+    TEST_CHECK(cio != NULL);
+    if (!cio) {
+        flb_input_exit_all(cfg);
+        flb_config_exit(cfg);
+        flb_free(root_path);
+        return;
+    }
+
+    flb_storage_input_create(cio, i_ins);
+    flb_input_init_all(cfg);
+
+    o_ins = flb_output_new(cfg, "null", NULL, FLB_TRUE);
+    TEST_CHECK(o_ins != NULL);
+    if (!o_ins) {
+        cio_destroy(cio);
+        flb_input_exit_all(cfg);
+        flb_config_exit(cfg);
+        flb_free(root_path);
+        return;
+    }
+    o_ins->id = 1;
+    flb_output_set_property(o_ins, "match", "*");
+
+    TEST_CHECK_(flb_router_io_set(cfg) != -1, "unable to configure router");
+
+    memset(payload, 0x41, sizeof(payload));
+    msgpack_sbuffer_init(&mp_sbuf);
+    gen_buf(&mp_sbuf, payload, sizeof(payload));
+
+    ret = flb_input_chunk_append_raw(i_ins, FLB_INPUT_LOGS, 1,
+                                     "dummy", 5, mp_sbuf.data, mp_sbuf.size);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(mk_list_size(&i_ins->chunks) == 1);
+    first_chunk = mk_list_entry_first(&i_ins->chunks,
+                                      struct flb_input_chunk, _head);
+    TEST_CHECK(cio_chunk_is_locked(first_chunk->chunk) == CIO_FALSE);
+
+    ret = flb_input_chunk_append_raw(i_ins, FLB_INPUT_LOGS, 1,
+                                     "dummy", 5, mp_sbuf.data, mp_sbuf.size);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(cio_chunk_is_locked(first_chunk->chunk) == CIO_TRUE);
+    TEST_CHECK(flb_input_chunk_get_size(first_chunk) > i_ins->storage_max_chunk_size);
+
+    ret = flb_input_chunk_append_raw(i_ins, FLB_INPUT_LOGS, 1,
+                                     "dummy", 5, mp_sbuf.data, mp_sbuf.size);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(mk_list_size(&i_ins->chunks) == 2);
+    second_chunk = mk_list_entry_last(&i_ins->chunks,
+                                      struct flb_input_chunk, _head);
+    TEST_CHECK(cio_chunk_is_locked(second_chunk->chunk) == CIO_FALSE);
+    TEST_CHECK(flb_input_chunk_get_size(second_chunk) < i_ins->storage_max_chunk_size);
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    mk_list_foreach_safe(head, tmp, &i_ins->chunks) {
+        ic = mk_list_entry(head, struct flb_input_chunk, _head);
+        flb_input_chunk_destroy(ic, FLB_TRUE);
+    }
+    cio_destroy(cio);
+    flb_router_exit(cfg);
+    flb_input_exit_all(cfg);
+    flb_output_exit(cfg);
+    flb_config_exit(cfg);
+    flb_free(root_path);
+}
+
 static int get_counter_value_1(struct cmt_counter *counter,
                                char *label_value_0,
                                double *value)
@@ -1297,6 +1423,8 @@ TEST_LIST = {
     {"input_chunk_buffer_valid",       flb_test_input_chunk_buffer_valid},
     {"input_chunk_dropping_chunks",    flb_test_input_chunk_dropping_chunks},
     {"input_chunk_fs_chunk_size_real", flb_test_input_chunk_fs_chunks_size_real},
+    {"input_chunk_configurable_max_size",
+     flb_test_input_chunk_configurable_max_size},
     {"input_chunk_correct_total_records", flb_test_input_chunk_correct_total_records},
     {"input_chunk_grouped_auto_records", flb_test_input_chunk_grouped_auto_records},
     {"input_chunk_grouped_release_space_drop_counters",


### PR DESCRIPTION
<!-- Provide summary of changes -->

Input chunks currently use a fixed soft limit of 2,048,000 bytes, which constrains batching for outputs such as Azure Logs Ingestion even when the workload compresses well.

This adds the advanced per-input `storage.max_chunk_size` setting while preserving the current default. The chunk manager uses the configured value consistently for locking and filesystem downing, and a tail-to-Azure integration case verifies that a file larger than 2 MB can be delivered in one gzip-compressed request with a `10M` setting. The limit remains soft, and compressed payload size remains workload-dependent.

## Risks

- Larger chunks increase peak memory and CPU because MessagePack, expanded JSON, and gzip buffers can coexist during a flush.
- Retries resend more records at once, increasing bandwidth use and the potential duplicate-ingestion blast radius.
- The setting applies to every output routed from the input, not only Azure Logs Ingestion.
- The threshold is soft, so the append that crosses `10M` can make the final chunk larger.
- Compression depends on record content; a 10 MB chunk can exceed Azure's compressed request limit and enter retries because the output does not split oversized requests.
- Flush cadence, traffic rate, and tag cardinality can dispatch smaller chunks, so a 600 KB compressed average is not guaranteed.

The safest rollout uses a dedicated tail input routed only to Azure, representative canary traffic, and monitoring for memory growth, HTTP 413 responses, and output retries.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

N/A

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Validated with:

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`
- `ctest --test-dir build -R '^flb-it-input_chunk$' --output-on-failure`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py -q` (2 passed)
- `LEAKS=1 LEAKS_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py::test_out_azure_logs_ingestion_tail_uses_configured_chunk_size -q` (1 passed)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

In-tree `CHUNKS.md` documentation is included.

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.