### PR TITLE
out_azure_logs_ingestion: batch requests by compressed size

### DIFF
--- a/plugins/out_azure_logs_ingestion/CMakeLists.txt
+++ b/plugins/out_azure_logs_ingestion/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(src
   azure_logs_ingestion.c
+  azure_logs_ingestion_batch.c
   azure_logs_ingestion_conf.c
   )
 

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -365,8 +365,8 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
         payload_size = flb_sds_len(payload);
 
         if (ctx->compress_enabled == FLB_TRUE) {
-            ret = flb_gzip_compress(payload, payload_size,
-                                    &compressed_payload, &payload_size);
+            ret = flb_az_li_gzip_compress(ctx, payload, payload_size,
+                                          &compressed_payload, &payload_size);
             if (ret == -1) {
                 flb_plg_error(ctx->ins,
                               "cannot gzip payload, disabling compression");
@@ -480,11 +480,16 @@ static struct flb_config_map config_map[] = {
      "Enable request buffering and batching by size and timeout."
     },
     {
-     FLB_CONFIG_MAP_SIZE, "batch_size", FLB_AZ_LI_BATCH_SIZE,
-     0, FLB_TRUE, offsetof(struct flb_az_li, batch_size),
-     "Set the maximum request size after optional compression. Batches are "
-     "split on record boundaries and normally sent between 70% and 100% of "
-     "this size."
+     FLB_CONFIG_MAP_SIZE, "max_batch_size", FLB_AZ_LI_MAX_BATCH_SIZE,
+     0, FLB_TRUE, offsetof(struct flb_az_li, max_batch_size),
+     "Set the maximum request size after optional compression."
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "min_batch_size", FLB_AZ_LI_MIN_BATCH_SIZE,
+     0, FLB_TRUE, offsetof(struct flb_az_li, min_batch_size),
+     "Set the minimum request size before an unexpired batch is sent. "
+     "Batch selection targets 90% of the range between the minimum and "
+     "maximum sizes."
     },
     {
      FLB_CONFIG_MAP_TIME, "batch_timeout", FLB_AZ_LI_BATCH_TIMEOUT,

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -250,6 +250,9 @@ static int process_batches(struct flb_az_li *ctx)
 
         ret = send_batch(ctx, &batch);
         if (ret != FLB_OK) {
+            pthread_mutex_lock(&ctx->batch_mutex);
+            ctx->batch_retry_pending = FLB_TRUE;
+            pthread_mutex_unlock(&ctx->batch_mutex);
             flb_az_li_batch_destroy(&batch);
             result = -1;
             break;
@@ -257,6 +260,9 @@ static int process_batches(struct flb_az_li *ctx)
 
         pthread_mutex_lock(&ctx->batch_mutex);
         ret = flb_az_li_batch_commit(ctx, &batch);
+        if (ret == 0) {
+            ctx->batch_retry_pending = FLB_FALSE;
+        }
         pthread_mutex_unlock(&ctx->batch_mutex);
         flb_az_li_batch_destroy(&batch);
 
@@ -476,8 +482,9 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "batch_size", FLB_AZ_LI_BATCH_SIZE,
      0, FLB_TRUE, offsetof(struct flb_az_li, batch_size),
-     "Set the target request size after optional compression. Batches are "
-     "split on record boundaries and sent when they reach this size."
+     "Set the maximum request size after optional compression. Batches are "
+     "split on record boundaries and normally sent between 70% and 100% of "
+     "this size."
     },
     {
      FLB_CONFIG_MAP_TIME, "batch_timeout", FLB_AZ_LI_BATCH_TIMEOUT,

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -317,7 +317,7 @@ static int cb_azure_logs_ingestion_pre_run(void *data, struct flb_config *config
 
     (void) config;
 
-    if (ctx->batching_enabled == FLB_FALSE) {
+    if (ctx->buffering_enabled == FLB_FALSE) {
         return 0;
     }
 
@@ -346,7 +346,7 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
     (void) i_ins;
     (void) config;
 
-    if (ctx->batching_enabled == FLB_FALSE) {
+    if (ctx->buffering_enabled == FLB_FALSE) {
         payload = NULL;
         compressed_payload = NULL;
         compressed = FLB_FALSE;
@@ -469,9 +469,9 @@ static struct flb_config_map config_map[] = {
      "Enable HTTP payload compression (gzip)."
     },
     {
-     FLB_CONFIG_MAP_BOOL, "batching_enabled", "false",
-     0, FLB_TRUE, offsetof(struct flb_az_li, batching_enabled),
-     "Enable request batching by size and timeout."
+     FLB_CONFIG_MAP_BOOL, "buffering_enabled", "false",
+     0, FLB_TRUE, offsetof(struct flb_az_li, buffering_enabled),
+     "Enable request buffering and batching by size and timeout."
     },
     {
      FLB_CONFIG_MAP_SIZE, "batch_size", FLB_AZ_LI_BATCH_SIZE,

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_oauth2.h>
 
@@ -122,13 +123,13 @@ token_cleanup:
     return token_return;
 }
 
-static int send_batch(struct flb_az_li *ctx, struct flb_az_li_batch *batch)
+static int send_payload(struct flb_az_li *ctx,
+                        void *payload, size_t payload_size,
+                        int compressed)
 {
     int ret;
     int flush_status;
     size_t b_sent;
-    void *final_payload;
-    size_t final_payload_size;
     flb_sds_t token = NULL;
     struct flb_connection *u_conn;
     struct flb_http_client *c = NULL;
@@ -144,27 +145,18 @@ static int send_batch(struct flb_az_li *ctx, struct flb_az_li_batch *batch)
         goto cleanup;
     }
 
-    if (ctx->compress_enabled == FLB_TRUE) {
-        final_payload = batch->compressed_payload;
-        final_payload_size = batch->compressed_size;
-    }
-    else {
-        final_payload = batch->payload;
-        final_payload_size = flb_sds_len(batch->payload);
-    }
-
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->dce_u_url,
-                        final_payload, final_payload_size, NULL, 0, NULL, 0);
+                        payload, payload_size, NULL, 0, NULL, 0);
 
     if (!c) {
-        flb_plg_warn(ctx->ins, "retrying payload bytes=%lu", final_payload_size);
+        flb_plg_warn(ctx->ins, "retrying payload bytes=%lu", payload_size);
         flush_status = FLB_RETRY;
         goto cleanup;
     }
 
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
-    if (ctx->compress_enabled == FLB_TRUE) {
+    if (compressed == FLB_TRUE) {
         flb_http_add_header(c, "Content-Encoding", 16, "gzip", 4);
     }
     flb_http_add_header(c, "Authorization", 13, token, flb_sds_len(token));
@@ -191,7 +183,7 @@ static int send_batch(struct flb_az_li *ctx, struct flb_az_li_batch *batch)
             else {
                 flb_plg_warn(ctx->ins, "http_status=%i", c->resp.status);
             }
-            flb_plg_debug(ctx->ins, "retrying payload bytes=%lu", final_payload_size);
+            flb_plg_debug(ctx->ins, "retrying payload bytes=%lu", payload_size);
             flush_status = FLB_RETRY;
             goto cleanup;
         }
@@ -211,6 +203,17 @@ cleanup:
     }
 
     return flush_status;
+}
+
+static int send_batch(struct flb_az_li *ctx, struct flb_az_li_batch *batch)
+{
+    if (ctx->compress_enabled == FLB_TRUE) {
+        return send_payload(ctx, batch->compressed_payload,
+                            batch->compressed_size, FLB_TRUE);
+    }
+
+    return send_payload(ctx, batch->payload,
+                        flb_sds_len(batch->payload), FLB_FALSE);
 }
 
 static int process_batches(struct flb_az_li *ctx)
@@ -314,6 +317,10 @@ static int cb_azure_logs_ingestion_pre_run(void *data, struct flb_config *config
 
     (void) config;
 
+    if (ctx->batching_enabled == FLB_FALSE) {
+        return 0;
+    }
+
     if (batch_timer_create(ctx) == -1) {
         flb_plg_error(ctx->ins, "could not create the batch flush timer");
         return -1;
@@ -329,11 +336,51 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
                                           struct flb_config *config)
 {
     int ret;
+    int compressed;
+    size_t payload_size;
+    void *compressed_payload;
+    flb_sds_t payload;
     struct flb_az_li *ctx = out_context;
 
     (void) out_flush;
     (void) i_ins;
     (void) config;
+
+    if (ctx->batching_enabled == FLB_FALSE) {
+        payload = NULL;
+        compressed_payload = NULL;
+        compressed = FLB_FALSE;
+
+        ret = flb_az_li_batch_format_chunk(ctx, event_chunk->data,
+                                           event_chunk->size, &payload);
+        if (ret == -1) {
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+        payload_size = flb_sds_len(payload);
+
+        if (ctx->compress_enabled == FLB_TRUE) {
+            ret = flb_gzip_compress(payload, payload_size,
+                                    &compressed_payload, &payload_size);
+            if (ret == -1) {
+                flb_plg_error(ctx->ins,
+                              "cannot gzip payload, disabling compression");
+            }
+            else {
+                compressed = FLB_TRUE;
+            }
+        }
+
+        if (compressed == FLB_TRUE) {
+            ret = send_payload(ctx, compressed_payload, payload_size, FLB_TRUE);
+            flb_free(compressed_payload);
+        }
+        else {
+            ret = send_payload(ctx, payload, payload_size, FLB_FALSE);
+        }
+        flb_sds_destroy(payload);
+
+        FLB_OUTPUT_RETURN(ret);
+    }
 
     if (batch_timer_create(ctx) == -1) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
@@ -420,6 +467,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "compress", "false",
      0, FLB_TRUE,  offsetof(struct flb_az_li, compress_enabled),
      "Enable HTTP payload compression (gzip)."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "batching_enabled", "false",
+     0, FLB_TRUE, offsetof(struct flb_az_li, batching_enabled),
+     "Enable request batching by size and timeout."
     },
     {
      FLB_CONFIG_MAP_SIZE, "batch_size", FLB_AZ_LI_BATCH_SIZE,

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -20,18 +20,9 @@
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_oauth2.h>
-#include <fluent-bit/flb_base64.h>
-#include <fluent-bit/flb_crypto.h>
-#include <fluent-bit/flb_gzip.h>
-#include <fluent-bit/flb_hmac.h>
-#include <fluent-bit/flb_pack.h>
-#include <fluent-bit/flb_mp.h>
-#include <fluent-bit/flb_utils.h>
-#include <fluent-bit/flb_time.h>
-#include <fluent-bit/flb_log_event_decoder.h>
-#include <msgpack.h>
 
 #include "azure_logs_ingestion.h"
+#include "azure_logs_ingestion_batch.h"
 #include "azure_logs_ingestion_conf.h"
 
 static int cb_azure_logs_ingestion_init(struct flb_output_instance *ins,
@@ -48,117 +39,6 @@ static int cb_azure_logs_ingestion_init(struct flb_output_instance *ins,
         flb_plg_error(ins, "configuration failed");
         return -1;
     }
-
-    return 0;
-}
-
-/* A duplicate function copied from the azure log analytics plugin.
-    allocates sds string */
-static int az_li_format(const void *in_buf, size_t in_bytes,
-                        char **out_buf, size_t *out_size,
-                        struct flb_az_li *ctx,
-                        struct flb_config *config)
-{
-    int i;
-    int ret;
-    int array_size = 0;
-    int map_size;
-    double t;
-    struct flb_time tm;
-    struct flb_log_event_decoder log_decoder;
-    struct flb_log_event log_event;
-    msgpack_object map;
-    msgpack_object k;
-    msgpack_object v;
-    msgpack_sbuffer mp_sbuf;
-    msgpack_packer mp_pck;
-    msgpack_sbuffer tmp_sbuf;
-    msgpack_packer tmp_pck;
-    flb_sds_t record;
-    char time_formatted[32];
-    size_t s;
-    struct tm tms;
-    int len;
-
-    /* Count number of items */
-    array_size = flb_mp_count_log_records(in_buf, in_bytes);
-
-    /* Create temporary msgpack buffer */
-    msgpack_sbuffer_init(&mp_sbuf);
-    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
-    msgpack_pack_array(&mp_pck, array_size);
-
-    ret = flb_log_event_decoder_init(&log_decoder, (char *) in_buf, in_bytes);
-    if (ret != FLB_EVENT_DECODER_SUCCESS) {
-        msgpack_sbuffer_destroy(&mp_sbuf);
-        return -1;
-    }
-
-    while ((ret = flb_log_event_decoder_next(&log_decoder, &log_event)) ==
-           FLB_EVENT_DECODER_SUCCESS) {
-        flb_time_copy(&tm, &log_event.timestamp);
-
-        /* Create temporary msgpack buffer */
-        msgpack_sbuffer_init(&tmp_sbuf);
-        msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
-
-        map = *log_event.body;
-        map_size = map.via.map.size;
-
-        msgpack_pack_map(&mp_pck, map_size + 1);
-
-        /* Append the time key */
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->time_key));
-        msgpack_pack_str_body(&mp_pck,
-                            ctx->time_key,
-                            flb_sds_len(ctx->time_key));
-
-        if (ctx->time_generated == FLB_TRUE) {
-            /* Append the time value as ISO 8601 */
-            gmtime_r(&tm.tm.tv_sec, &tms);
-            s = strftime(time_formatted, sizeof(time_formatted) - 1,
-                            FLB_PACK_JSON_DATE_ISO8601_FMT, &tms);
-
-            len = snprintf(time_formatted + s,
-                            sizeof(time_formatted) - 1 - s,
-                            ".%03" PRIu64 "Z",
-                            (uint64_t) tm.tm.tv_nsec / 1000000);
-            s += len;
-            msgpack_pack_str(&mp_pck, s);
-            msgpack_pack_str_body(&mp_pck, time_formatted, s);
-        }
-        else {
-            /* Append the time value as millis.nanos */
-            t = flb_time_to_double(&tm);
-            msgpack_pack_double(&mp_pck, t);
-        }
-
-        /* Append original map k/v */
-        for (i = 0; i < map_size; i++) {
-            k = map.via.map.ptr[i].key;
-            v = map.via.map.ptr[i].val;
-
-            msgpack_pack_object(&tmp_pck, k);
-            msgpack_pack_object(&tmp_pck, v);
-        }
-        msgpack_sbuffer_write(&mp_sbuf, tmp_sbuf.data, tmp_sbuf.size);
-        msgpack_sbuffer_destroy(&tmp_sbuf);
-    }
-
-    record = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size,
-                                         config->json_escape_unicode);
-    if (!record) {
-        flb_errno();
-        msgpack_sbuffer_destroy(&mp_sbuf);
-        flb_log_event_decoder_destroy(&log_decoder);
-        return -1;
-    }
-
-    msgpack_sbuffer_destroy(&mp_sbuf);
-    flb_log_event_decoder_destroy(&log_decoder);
-
-    *out_buf = record;
-    *out_size = flb_sds_len(record);
 
     return 0;
 }
@@ -242,67 +122,37 @@ token_cleanup:
     return token_return;
 }
 
-static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
-                           struct flb_output_flush *out_flush,
-                           struct flb_input_instance *i_ins,
-                           void *out_context,
-                           struct flb_config *config)
+static int send_batch(struct flb_az_li *ctx, struct flb_az_li_batch *batch)
 {
     int ret;
     int flush_status;
     size_t b_sent;
-    size_t json_payload_size;
-    void* final_payload;
+    void *final_payload;
     size_t final_payload_size;
-    flb_sds_t token;
+    flb_sds_t token = NULL;
     struct flb_connection *u_conn;
     struct flb_http_client *c = NULL;
-    int is_compressed = FLB_FALSE;
-    flb_sds_t json_payload = NULL;
-    struct flb_az_li *ctx = out_context;
-    (void) i_ins;
-    (void) config;
 
-    /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u_dce);
     if (!u_conn) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+        return FLB_RETRY;
     }
 
-    /* Convert binary logs into a JSON payload */
-    ret = az_li_format(event_chunk->data, event_chunk->size,
-                       &json_payload, &json_payload_size, ctx,
-                       config);
-    if (ret == -1) {
-        flb_upstream_conn_release(u_conn);
-        FLB_OUTPUT_RETURN(FLB_ERROR);
-    }
-
-    /* Get OAuth2 token */
     token = get_az_li_token(ctx);
     if (!token) {
         flush_status = FLB_RETRY;
         goto cleanup;
     }
 
-    /* Map buffer */
-    final_payload = json_payload;
-    final_payload_size = json_payload_size;
     if (ctx->compress_enabled == FLB_TRUE) {
-        ret = flb_gzip_compress((void *) json_payload, json_payload_size,
-                                &final_payload, &final_payload_size);
-        if (ret == -1) {
-            flb_plg_error(ctx->ins,
-                          "cannot gzip payload, disabling compression");
-        }
-        else {
-            is_compressed = FLB_TRUE;
-            flb_plg_debug(ctx->ins, "enabled payload gzip compression");
-            /* JSON buffer will be cleared at cleanup: */
-        }
+        final_payload = batch->compressed_payload;
+        final_payload_size = batch->compressed_size;
+    }
+    else {
+        final_payload = batch->payload;
+        final_payload_size = flb_sds_len(batch->payload);
     }
 
-    /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->dce_u_url,
                         final_payload, final_payload_size, NULL, 0, NULL, 0);
 
@@ -312,16 +162,14 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
         goto cleanup;
     }
 
-    /* Append headers */
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
-    if (is_compressed) {
+    if (ctx->compress_enabled == FLB_TRUE) {
         flb_http_add_header(c, "Content-Encoding", 16, "gzip", 4);
     }
     flb_http_add_header(c, "Authorization", 13, token, flb_sds_len(token));
     flb_http_buffer_size(c, FLB_HTTP_DATA_SIZE_MAX);
 
-    /* Execute rest call */
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {
         flb_plg_warn(ctx->ins, "http_do=%i", ret);
@@ -350,16 +198,6 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
     }
 
 cleanup:
-    /* cleanup */
-    if (json_payload) {
-        flb_sds_destroy(json_payload);
-    }
-
-    /* release compressed payload */
-    if (is_compressed == FLB_TRUE) {
-        flb_free(final_payload);
-    }
-
     if (c) {
         flb_http_client_destroy(c);
     }
@@ -371,7 +209,148 @@ cleanup:
     if (token) {
         flb_sds_destroy(token);
     }
-    FLB_OUTPUT_RETURN(flush_status);
+
+    return flush_status;
+}
+
+static int process_batches(struct flb_az_li *ctx)
+{
+    int ret;
+    int result;
+    struct flb_az_li_batch batch;
+
+    pthread_mutex_lock(&ctx->batch_mutex);
+    if (ctx->batch_processing == FLB_TRUE) {
+        pthread_mutex_unlock(&ctx->batch_mutex);
+        return 0;
+    }
+    ctx->batch_processing = FLB_TRUE;
+    pthread_mutex_unlock(&ctx->batch_mutex);
+
+    result = 0;
+
+    while (1) {
+        pthread_mutex_lock(&ctx->batch_mutex);
+        ret = flb_az_li_batch_prepare(ctx, &batch);
+        pthread_mutex_unlock(&ctx->batch_mutex);
+
+        if (ret == FLB_AZ_LI_BATCH_CORRUPT_FILE) {
+            continue;
+        }
+
+        if (ret <= 0) {
+            if (ret == -1) {
+                result = -1;
+            }
+            break;
+        }
+
+        ret = send_batch(ctx, &batch);
+        if (ret != FLB_OK) {
+            flb_az_li_batch_destroy(&batch);
+            result = -1;
+            break;
+        }
+
+        pthread_mutex_lock(&ctx->batch_mutex);
+        ret = flb_az_li_batch_commit(ctx, &batch);
+        pthread_mutex_unlock(&ctx->batch_mutex);
+        flb_az_li_batch_destroy(&batch);
+
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not commit the buffered batch");
+            result = -1;
+            break;
+        }
+    }
+
+    pthread_mutex_lock(&ctx->batch_mutex);
+    ctx->batch_processing = FLB_FALSE;
+    pthread_mutex_unlock(&ctx->batch_mutex);
+
+    return result;
+}
+
+static void batch_timer_callback(struct flb_config *config, void *data)
+{
+    struct flb_az_li *ctx = data;
+
+    (void) config;
+
+    process_batches(ctx);
+    flb_sched_timer_cb_coro_return();
+}
+
+static int batch_timer_create(struct flb_az_li *ctx)
+{
+    int ret;
+    struct flb_sched *scheduler;
+
+    pthread_mutex_lock(&ctx->batch_mutex);
+    if (ctx->timer_created == FLB_TRUE) {
+        pthread_mutex_unlock(&ctx->batch_mutex);
+        return 0;
+    }
+
+    scheduler = flb_sched_ctx_get();
+    if (scheduler == NULL) {
+        pthread_mutex_unlock(&ctx->batch_mutex);
+        return -1;
+    }
+
+    ret = flb_sched_timer_coro_cb_create(scheduler, FLB_SCHED_TIMER_CB_PERM,
+                                         1000, batch_timer_callback, ctx, NULL);
+    if (ret == 0) {
+        ctx->timer_created = FLB_TRUE;
+    }
+    pthread_mutex_unlock(&ctx->batch_mutex);
+
+    return ret;
+}
+
+static int cb_azure_logs_ingestion_pre_run(void *data, struct flb_config *config)
+{
+    struct flb_az_li *ctx = data;
+
+    (void) config;
+
+    if (batch_timer_create(ctx) == -1) {
+        flb_plg_error(ctx->ins, "could not create the batch flush timer");
+        return -1;
+    }
+
+    return 0;
+}
+
+static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
+                                          struct flb_output_flush *out_flush,
+                                          struct flb_input_instance *i_ins,
+                                          void *out_context,
+                                          struct flb_config *config)
+{
+    int ret;
+    struct flb_az_li *ctx = out_context;
+
+    (void) out_flush;
+    (void) i_ins;
+    (void) config;
+
+    if (batch_timer_create(ctx) == -1) {
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    pthread_mutex_lock(&ctx->batch_mutex);
+    ret = flb_az_li_batch_append(ctx, event_chunk->data, event_chunk->size);
+    pthread_mutex_unlock(&ctx->batch_mutex);
+    if (ret == -1) {
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    if (process_batches(ctx) == -1) {
+        flb_plg_warn(ctx->ins, "buffered batches remain pending");
+    }
+
+    FLB_OUTPUT_RETURN(FLB_OK);
 }
 
 static int cb_azure_logs_ingestion_exit(void *data, struct flb_config *config)
@@ -442,6 +421,27 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE,  offsetof(struct flb_az_li, compress_enabled),
      "Enable HTTP payload compression (gzip)."
     },
+    {
+     FLB_CONFIG_MAP_SIZE, "batch_size", FLB_AZ_LI_BATCH_SIZE,
+     0, FLB_TRUE, offsetof(struct flb_az_li, batch_size),
+     "Set the target request size after optional compression. Batches are "
+     "split on record boundaries and sent when they reach this size."
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "batch_timeout", FLB_AZ_LI_BATCH_TIMEOUT,
+     0, FLB_TRUE, offsetof(struct flb_az_li, batch_timeout),
+     "Set the maximum time to postpone an underfilled batch."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "store_dir", FLB_AZ_LI_STORE_DIR,
+     0, FLB_TRUE, offsetof(struct flb_az_li, store_dir),
+     "Set the directory used to stage pending batches."
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "store_dir_limit_size", "0",
+     0, FLB_TRUE, offsetof(struct flb_az_li, store_dir_limit_size),
+     "Limit the staged batch data size (0 means unlimited)."
+    },
     /* EOF */
     {0}
 };
@@ -450,6 +450,7 @@ struct flb_output_plugin out_azure_logs_ingestion_plugin = {
     .name         = "azure_logs_ingestion",
     .description  = "Send logs to Log Analytics with Log Ingestion API",
     .cb_init      = cb_azure_logs_ingestion_init,
+    .cb_pre_run   = cb_azure_logs_ingestion_pre_run,
     .cb_flush     = cb_azure_logs_ingestion_flush,
     .cb_exit      = cb_azure_logs_ingestion_exit,
 
@@ -457,5 +458,6 @@ struct flb_output_plugin out_azure_logs_ingestion_plugin = {
     .config_map     = config_map,
 
     /* Plugin flags */
-    .flags          = FLB_OUTPUT_NET | FLB_IO_TLS,
+    .event_type     = FLB_OUTPUT_LOGS,
+    .flags          = FLB_OUTPUT_NET | FLB_IO_TLS | FLB_OUTPUT_SYNCHRONOUS,
 };

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -33,9 +33,14 @@
 #define FLB_AZ_LI_TLS_MODE          FLB_IO_TLS
 /* refresh token every 60 minutes */
 #define FLB_AZ_LI_TOKEN_TIMEOUT 3600
+#define FLB_AZ_LI_BATCH_SIZE    "900K"
+#define FLB_AZ_LI_BATCH_TIMEOUT "30s"
+#define FLB_AZ_LI_STORE_DIR     "/tmp/fluent-bit/azure-logs-ingestion"
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_fstore.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_sds.h>
 
 /* Context structure for Azure Logs Ingestion API */
@@ -56,12 +61,28 @@ struct flb_az_li {
     /* compress payload */
     int compress_enabled;
 
+    /* request batching */
+    size_t batch_size;
+    int batch_timeout;
+    flb_sds_t store_dir;
+    size_t store_dir_limit_size;
+    size_t buffered_size;
+    uint64_t store_sequence;
+    int batch_processing;
+    int timer_created;
+    struct flb_fstore *fs;
+    struct flb_fstore_stream *fs_stream;
+    flb_sds_t fs_stream_name;
+    pthread_mutex_t batch_mutex;
+    int batch_mutex_initialized;
+
     /* mangement auth */
     flb_sds_t auth_url_override;
     flb_sds_t auth_url;
     struct flb_oauth2 *u_auth;
     /* mutex for acquiring tokens */
     pthread_mutex_t token_mutex;
+    int token_mutex_initialized;
 
     /* upstream connection to the data collection endpoint */
     struct flb_upstream *u_dce;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -42,6 +42,7 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_sds.h>
+#include <cmetrics/cmt_gauge.h>
 
 /* Context structure for Azure Logs Ingestion API */
 struct flb_az_li {
@@ -69,11 +70,20 @@ struct flb_az_li {
     size_t store_dir_limit_size;
     size_t buffered_size;
     uint64_t store_sequence;
+    uint64_t buffer_generation;
+    uint64_t last_probe_generation;
+    size_t last_probe_uncompressed_size;
+    double compression_ratio;
+    double average_compression_ratio;
     int batch_processing;
+    int batch_retry_pending;
     int timer_created;
     struct flb_fstore *fs;
     struct flb_fstore_stream *fs_stream;
     flb_sds_t fs_stream_name;
+#ifdef FLB_HAVE_METRICS
+    struct cmt_gauge *cmt_compression_ratio;
+#endif
     pthread_mutex_t batch_mutex;
     int batch_mutex_initialized;
 

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -33,7 +33,7 @@
 #define FLB_AZ_LI_TLS_MODE          FLB_IO_TLS
 /* refresh token every 60 minutes */
 #define FLB_AZ_LI_TOKEN_TIMEOUT 3600
-#define FLB_AZ_LI_BATCH_SIZE    "900K"
+#define FLB_AZ_LI_BATCH_SIZE    "1048576"
 #define FLB_AZ_LI_BATCH_TIMEOUT "30s"
 #define FLB_AZ_LI_STORE_DIR     "/tmp/fluent-bit/azure-logs-ingestion"
 
@@ -62,6 +62,7 @@ struct flb_az_li {
     int compress_enabled;
 
     /* request batching */
+    int batching_enabled;
     size_t batch_size;
     int batch_timeout;
     flb_sds_t store_dir;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -33,15 +33,17 @@
 #define FLB_AZ_LI_TLS_MODE          FLB_IO_TLS
 /* refresh token every 60 minutes */
 #define FLB_AZ_LI_TOKEN_TIMEOUT 3600
-#define FLB_AZ_LI_BATCH_SIZE    "1048576"
-#define FLB_AZ_LI_BATCH_TIMEOUT "30s"
-#define FLB_AZ_LI_STORE_DIR     "/tmp/fluent-bit/azure-logs-ingestion"
+#define FLB_AZ_LI_MAX_BATCH_SIZE "1048576"
+#define FLB_AZ_LI_MIN_BATCH_SIZE "204800"
+#define FLB_AZ_LI_BATCH_TIMEOUT  "30s"
+#define FLB_AZ_LI_STORE_DIR      "/tmp/fluent-bit/azure-logs-ingestion"
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_fstore.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_sds.h>
+#include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
 
 /* Context structure for Azure Logs Ingestion API */
@@ -64,7 +66,8 @@ struct flb_az_li {
 
     /* request batching */
     int buffering_enabled;
-    size_t batch_size;
+    size_t max_batch_size;
+    size_t min_batch_size;
     int batch_timeout;
     flb_sds_t store_dir;
     size_t store_dir_limit_size;
@@ -83,6 +86,7 @@ struct flb_az_li {
     flb_sds_t fs_stream_name;
 #ifdef FLB_HAVE_METRICS
     struct cmt_gauge *cmt_compression_ratio;
+    struct cmt_counter *cmt_gzip_operations;
 #endif
     pthread_mutex_t batch_mutex;
     int batch_mutex_initialized;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -62,7 +62,7 @@ struct flb_az_li {
     int compress_enabled;
 
     /* request batching */
-    int batching_enabled;
+    int buffering_enabled;
     size_t batch_size;
     int batch_timeout;
     flb_sds_t store_dir;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
@@ -28,7 +28,7 @@
 
 #include "azure_logs_ingestion_batch.h"
 
-#define FLB_AZ_LI_BATCH_MIN_PERCENT 70
+#define FLB_AZ_LI_BATCH_TARGET_PERCENT 90
 #define FLB_AZ_LI_BATCH_PERCENT_SCALE 100
 #define FLB_AZ_LI_COMPRESSION_RATIO_OLD_WEIGHT 0.75
 #define FLB_AZ_LI_COMPRESSION_RATIO_NEW_WEIGHT 0.25
@@ -449,7 +449,20 @@ static int batch_record_add(struct flb_az_li_batch *batch,
     return 0;
 }
 
-static int compress_prefix(struct flb_az_li_batch *batch, size_t record_count,
+int flb_az_li_gzip_compress(struct flb_az_li *ctx,
+                            void *in_data, size_t in_len,
+                            void **out_data, size_t *out_len)
+{
+#ifdef FLB_HAVE_METRICS
+    cmt_counter_inc(ctx->cmt_gzip_operations, cfl_time_now(), 1,
+                    (char *[]) {(char *) flb_output_name(ctx->ins)});
+#endif
+
+    return flb_gzip_compress(in_data, in_len, out_data, out_len);
+}
+
+static int compress_prefix(struct flb_az_li *ctx,
+                           struct flb_az_li_batch *batch, size_t record_count,
                            void **compressed_payload, size_t *compressed_size)
 {
     int ret;
@@ -460,8 +473,8 @@ static int compress_prefix(struct flb_az_li_batch *batch, size_t record_count,
     saved_character = batch->payload[json_end];
     batch->payload[json_end] = ']';
 
-    ret = flb_gzip_compress(batch->payload, json_end + 1,
-                            compressed_payload, compressed_size);
+    ret = flb_az_li_gzip_compress(ctx, batch->payload, json_end + 1,
+                                  compressed_payload, compressed_size);
     batch->payload[json_end] = saved_character;
 
     return ret;
@@ -478,27 +491,16 @@ static size_t scale_size(size_t size, size_t numerator, size_t denominator)
     return quotient * numerator + remainder * numerator / denominator;
 }
 
-static size_t batch_minimum_size(struct flb_az_li *ctx)
+static size_t batch_target_size(struct flb_az_li *ctx)
 {
-    size_t minimum_size;
+    size_t size_range;
 
-    minimum_size = scale_size(ctx->batch_size,
-                              FLB_AZ_LI_BATCH_MIN_PERCENT,
-                              FLB_AZ_LI_BATCH_PERCENT_SCALE);
-    if (minimum_size == 0) {
-        minimum_size = 1;
-    }
+    size_range = ctx->max_batch_size - ctx->min_batch_size;
 
-    return minimum_size;
-}
-
-static size_t batch_midpoint_size(struct flb_az_li *ctx)
-{
-    size_t minimum_size;
-
-    minimum_size = batch_minimum_size(ctx);
-
-    return minimum_size + (ctx->batch_size - minimum_size) / 2;
+    return ctx->min_batch_size +
+           scale_size(size_range,
+                      FLB_AZ_LI_BATCH_TARGET_PERCENT,
+                      FLB_AZ_LI_BATCH_PERCENT_SCALE);
 }
 
 static void update_compression_ratio_estimate(struct flb_az_li *ctx,
@@ -559,7 +561,8 @@ static int measure_prefix(struct flb_az_li *ctx,
     }
 
     compressed_payload = NULL;
-    ret = compress_prefix(batch, record_count, &compressed_payload, request_size);
+    ret = compress_prefix(ctx, batch, record_count,
+                          &compressed_payload, request_size);
     if (ret == -1) {
         return -1;
     }
@@ -605,14 +608,14 @@ static size_t project_uncompressed_size(size_t uncompressed_size,
 static size_t predicted_uncompressed_size(struct flb_az_li *ctx)
 {
     long double predicted_size;
-    size_t midpoint_size;
+    size_t target_size;
 
-    midpoint_size = batch_midpoint_size(ctx);
+    target_size = batch_target_size(ctx);
     if (ctx->compress_enabled == FLB_FALSE || ctx->compression_ratio <= 0) {
-        return midpoint_size;
+        return target_size;
     }
 
-    predicted_size = (long double) midpoint_size *
+    predicted_size = (long double) target_size *
                      (long double) ctx->compression_ratio;
     if (predicted_size >= (long double) SIZE_MAX) {
         return SIZE_MAX;
@@ -704,11 +707,11 @@ static int finalize_batch(struct flb_az_li *ctx,
         batch->measured_size = request_size;
     }
 
-    if (selected_count == 1 && request_size > ctx->batch_size) {
+    if (selected_count == 1 && request_size > ctx->max_batch_size) {
         flb_plg_warn(ctx->ins,
                      "single log record exceeds the batch target: "
                      "bytes=%zu target=%zu",
-                     request_size, ctx->batch_size);
+                     request_size, ctx->max_batch_size);
     }
 
     flb_plg_debug(ctx->ins,
@@ -740,11 +743,11 @@ static int finalize_oversized_batch(struct flb_az_li *ctx,
     safe_size = 0;
     low_count = 0;
     high_count = record_count;
-    minimum_size = batch_minimum_size(ctx);
-    target_size = batch_midpoint_size(ctx);
+    minimum_size = ctx->min_batch_size;
+    target_size = batch_target_size(ctx);
 
     while (1) {
-        if (request_size <= ctx->batch_size) {
+        if (request_size <= ctx->max_batch_size) {
             if (request_size >= minimum_size) {
                 flb_free(safe_payload);
                 return finalize_batch(ctx, batch, record_count);
@@ -850,7 +853,7 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
     int decoder_result;
     int expired;
     size_t minimum_size;
-    size_t midpoint_size;
+    size_t target_size;
     size_t next_check;
     size_t file_size;
     size_t request_size;
@@ -864,7 +867,7 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
     struct flb_log_event log_event;
 
     memset(batch, 0, sizeof(struct flb_az_li_batch));
-    batch->payload = flb_sds_create_size(ctx->batch_size + 1);
+    batch->payload = flb_sds_create_size(ctx->max_batch_size + 1);
     if (batch->payload == NULL) {
         flb_errno();
         return -1;
@@ -876,8 +879,8 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
         return -1;
     }
 
-    minimum_size = batch_minimum_size(ctx);
-    midpoint_size = batch_midpoint_size(ctx);
+    minimum_size = ctx->min_batch_size;
+    target_size = batch_target_size(ctx);
     next_check = predicted_uncompressed_size(ctx);
 
     mk_list_foreach_safe(head, temporary, &ctx->fs_stream->files) {
@@ -959,7 +962,7 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
                     return -1;
                 }
 
-                if (request_size > ctx->batch_size) {
+                if (request_size > ctx->max_batch_size) {
                     flb_log_event_decoder_destroy(&decoder);
                     flb_free(file_data);
                     ret = finalize_oversized_batch(ctx, batch,
@@ -984,7 +987,7 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
 
                 next_check = project_uncompressed_size(
                     record_json_size(batch, batch->record_count),
-                    request_size, midpoint_size);
+                    request_size, target_size);
                 if (next_check <= flb_sds_len(batch->payload)) {
                     next_check = flb_sds_len(batch->payload) + 1;
                 }
@@ -1036,7 +1039,7 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
         return 0;
     }
 
-    if (request_size > ctx->batch_size) {
+    if (request_size > ctx->max_batch_size) {
         ret = finalize_oversized_batch(ctx, batch, batch->record_count,
                                        request_size);
     }

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
@@ -28,7 +28,10 @@
 
 #include "azure_logs_ingestion_batch.h"
 
-#define FLB_AZ_LI_BATCH_CHECK_MIN 65536
+#define FLB_AZ_LI_BATCH_MIN_PERCENT 70
+#define FLB_AZ_LI_BATCH_PERCENT_SCALE 100
+#define FLB_AZ_LI_COMPRESSION_RATIO_OLD_WEIGHT 0.75
+#define FLB_AZ_LI_COMPRESSION_RATIO_NEW_WEIGHT 0.25
 #define FLB_AZ_LI_STORE_META_VERSION 1
 
 struct flb_az_li_store_meta {
@@ -280,6 +283,7 @@ int flb_az_li_batch_append(struct flb_az_li *ctx, const void *data, size_t size)
     }
 
     ctx->buffered_size += size;
+    ctx->buffer_generation++;
     return 0;
 }
 
@@ -463,6 +467,80 @@ static int compress_prefix(struct flb_az_li_batch *batch, size_t record_count,
     return ret;
 }
 
+static size_t scale_size(size_t size, size_t numerator, size_t denominator)
+{
+    size_t quotient;
+    size_t remainder;
+
+    quotient = size / denominator;
+    remainder = size % denominator;
+
+    return quotient * numerator + remainder * numerator / denominator;
+}
+
+static size_t batch_minimum_size(struct flb_az_li *ctx)
+{
+    size_t minimum_size;
+
+    minimum_size = scale_size(ctx->batch_size,
+                              FLB_AZ_LI_BATCH_MIN_PERCENT,
+                              FLB_AZ_LI_BATCH_PERCENT_SCALE);
+    if (minimum_size == 0) {
+        minimum_size = 1;
+    }
+
+    return minimum_size;
+}
+
+static size_t batch_midpoint_size(struct flb_az_li *ctx)
+{
+    size_t minimum_size;
+
+    minimum_size = batch_minimum_size(ctx);
+
+    return minimum_size + (ctx->batch_size - minimum_size) / 2;
+}
+
+static void update_compression_ratio_estimate(struct flb_az_li *ctx,
+                                              size_t uncompressed_size,
+                                              size_t compressed_size)
+{
+    if (compressed_size == 0) {
+        return;
+    }
+
+    ctx->compression_ratio =
+        (double) uncompressed_size / (double) compressed_size;
+}
+
+static void update_average_compression_ratio(struct flb_az_li *ctx,
+                                             size_t uncompressed_size,
+                                             size_t compressed_size)
+{
+    double observed_ratio;
+
+    if (compressed_size == 0) {
+        return;
+    }
+
+    observed_ratio = (double) uncompressed_size / (double) compressed_size;
+    if (ctx->average_compression_ratio == 0) {
+        ctx->average_compression_ratio = observed_ratio;
+    }
+    else {
+        ctx->average_compression_ratio =
+            ctx->average_compression_ratio *
+                FLB_AZ_LI_COMPRESSION_RATIO_OLD_WEIGHT +
+            observed_ratio * FLB_AZ_LI_COMPRESSION_RATIO_NEW_WEIGHT;
+    }
+
+#ifdef FLB_HAVE_METRICS
+    cmt_gauge_set(ctx->cmt_compression_ratio, cfl_time_now(),
+                  ctx->average_compression_ratio, 1,
+                  (char *[]) {(char *) flb_output_name(ctx->ins)});
+#endif
+}
+
 static int measure_prefix(struct flb_az_li *ctx,
                           struct flb_az_li_batch *batch,
                           size_t record_count,
@@ -475,6 +553,8 @@ static int measure_prefix(struct flb_az_li *ctx,
     json_end = batch->records[record_count - 1].json_end;
     if (ctx->compress_enabled == FLB_FALSE) {
         *request_size = json_end + 1;
+        batch->measured_record_count = record_count;
+        batch->measured_size = *request_size;
         return 0;
     }
 
@@ -484,47 +564,109 @@ static int measure_prefix(struct flb_az_li *ctx,
         return -1;
     }
 
-    flb_free(compressed_payload);
+    if (batch->compressed_payload != NULL) {
+        flb_free(batch->compressed_payload);
+    }
+    batch->compressed_payload = compressed_payload;
+    batch->compressed_size = *request_size;
+    batch->measured_record_count = record_count;
+    batch->measured_size = *request_size;
+    batch->gzip_operations++;
+    ctx->last_probe_generation = ctx->buffer_generation;
+    ctx->last_probe_uncompressed_size = json_end + 1;
+
+    update_compression_ratio_estimate(ctx, json_end + 1, *request_size);
 
     return 0;
 }
 
-static int select_record_count(struct flb_az_li *ctx,
-                               struct flb_az_li_batch *batch,
-                               size_t last_good_count,
-                               size_t *selected_count)
+static size_t project_uncompressed_size(size_t uncompressed_size,
+                                       size_t compressed_size,
+                                       size_t target_size)
 {
-    int ret;
+    long double projected_size;
+
+    if (compressed_size == 0) {
+        return uncompressed_size;
+    }
+
+    projected_size = (long double) uncompressed_size * (long double) target_size /
+                     (long double) compressed_size;
+    if (projected_size >= (long double) SIZE_MAX) {
+        return SIZE_MAX;
+    }
+    if (projected_size < 1) {
+        return 1;
+    }
+
+    return (size_t) projected_size;
+}
+
+static size_t predicted_uncompressed_size(struct flb_az_li *ctx)
+{
+    long double predicted_size;
+    size_t midpoint_size;
+
+    midpoint_size = batch_midpoint_size(ctx);
+    if (ctx->compress_enabled == FLB_FALSE || ctx->compression_ratio <= 0) {
+        return midpoint_size;
+    }
+
+    predicted_size = (long double) midpoint_size *
+                     (long double) ctx->compression_ratio;
+    if (predicted_size >= (long double) SIZE_MAX) {
+        return SIZE_MAX;
+    }
+    if (predicted_size < 1) {
+        return 1;
+    }
+
+    return (size_t) predicted_size;
+}
+
+static size_t record_json_size(struct flb_az_li_batch *batch,
+                               size_t record_count)
+{
+    return batch->records[record_count - 1].json_end + 1;
+}
+
+static size_t nearest_record_count(struct flb_az_li_batch *batch,
+                                  size_t target_size,
+                                  size_t maximum_count)
+{
     size_t low;
     size_t high;
     size_t middle;
-    size_t request_size;
+    size_t previous_size;
+    size_t current_size;
 
-    low = last_good_count;
-    high = batch->record_count;
+    if (maximum_count == 1 ||
+        target_size <= record_json_size(batch, 1)) {
+        return 1;
+    }
+    if (target_size >= record_json_size(batch, maximum_count)) {
+        return maximum_count;
+    }
 
+    low = 1;
+    high = maximum_count;
     while (low < high) {
-        middle = low + (high - low + 1) / 2;
-
-        ret = measure_prefix(ctx, batch, middle, &request_size);
-        if (ret == -1) {
-            return -1;
-        }
-
-        if (request_size <= ctx->batch_size) {
-            low = middle;
+        middle = low + (high - low) / 2;
+        if (record_json_size(batch, middle) < target_size) {
+            low = middle + 1;
         }
         else {
-            high = middle - 1;
+            high = middle;
         }
     }
 
-    if (low == 0) {
-        low = 1;
+    current_size = record_json_size(batch, low);
+    previous_size = record_json_size(batch, low - 1);
+    if (target_size - previous_size <= current_size - target_size) {
+        return low - 1;
     }
 
-    *selected_count = low;
-    return 0;
+    return low;
 }
 
 static int finalize_batch(struct flb_az_li *ctx,
@@ -534,6 +676,14 @@ static int finalize_batch(struct flb_az_li *ctx,
     int ret;
     size_t json_end;
     size_t request_size;
+
+    if (ctx->compress_enabled == FLB_TRUE &&
+        batch->measured_record_count != selected_count) {
+        ret = measure_prefix(ctx, batch, selected_count, &request_size);
+        if (ret == -1) {
+            return -1;
+        }
+    }
 
     json_end = batch->records[selected_count - 1].json_end;
     flb_sds_len_set(batch->payload, json_end);
@@ -546,14 +696,12 @@ static int finalize_batch(struct flb_az_li *ctx,
 
     batch->record_count = selected_count;
     request_size = flb_sds_len(batch->payload);
+    batch->measured_record_count = selected_count;
+    batch->measured_size = request_size;
 
     if (ctx->compress_enabled == FLB_TRUE) {
-        ret = flb_gzip_compress(batch->payload, flb_sds_len(batch->payload),
-                                &batch->compressed_payload, &batch->compressed_size);
-        if (ret == -1) {
-            return -1;
-        }
         request_size = batch->compressed_size;
+        batch->measured_size = request_size;
     }
 
     if (selected_count == 1 && request_size > ctx->batch_size) {
@@ -563,7 +711,99 @@ static int finalize_batch(struct flb_az_li *ctx,
                      request_size, ctx->batch_size);
     }
 
+    flb_plg_debug(ctx->ins,
+                  "prepared buffered batch records=%zu bytes=%zu "
+                  "gzip_operations=%zu",
+                  selected_count, request_size, batch->gzip_operations);
+
     return 0;
+}
+
+static int finalize_oversized_batch(struct flb_az_li *ctx,
+                                   struct flb_az_li_batch *batch,
+                                   size_t record_count,
+                                   size_t request_size)
+{
+    int ret;
+    void *safe_payload;
+    size_t high_count;
+    size_t low_count;
+    size_t minimum_size;
+    size_t safe_count;
+    size_t safe_size;
+    size_t target_size;
+    size_t projected_size;
+    size_t selected_count;
+
+    safe_payload = NULL;
+    safe_count = 0;
+    safe_size = 0;
+    low_count = 0;
+    high_count = record_count;
+    minimum_size = batch_minimum_size(ctx);
+    target_size = batch_midpoint_size(ctx);
+
+    while (1) {
+        if (request_size <= ctx->batch_size) {
+            if (request_size >= minimum_size) {
+                flb_free(safe_payload);
+                return finalize_batch(ctx, batch, record_count);
+            }
+
+            if (ctx->compress_enabled == FLB_TRUE) {
+                flb_free(safe_payload);
+                safe_payload = batch->compressed_payload;
+                batch->compressed_payload = NULL;
+            }
+            safe_count = record_count;
+            safe_size = request_size;
+            low_count = record_count;
+        }
+        else {
+            high_count = record_count;
+        }
+
+        if (high_count <= 1) {
+            flb_free(safe_payload);
+            return finalize_batch(ctx, batch, 1);
+        }
+
+        if (low_count + 1 >= high_count) {
+            if (safe_count == 0) {
+                flb_free(safe_payload);
+                return finalize_batch(ctx, batch, 1);
+            }
+
+            if (ctx->compress_enabled == FLB_TRUE) {
+                flb_free(batch->compressed_payload);
+                batch->compressed_payload = safe_payload;
+                batch->compressed_size = safe_size;
+                safe_payload = NULL;
+            }
+            batch->measured_record_count = safe_count;
+            batch->measured_size = safe_size;
+
+            return finalize_batch(ctx, batch, safe_count);
+        }
+
+        projected_size = project_uncompressed_size(
+            record_json_size(batch, record_count), request_size, target_size);
+        selected_count = nearest_record_count(batch, projected_size,
+                                             high_count - 1);
+        if (selected_count <= low_count) {
+            selected_count = low_count + 1;
+        }
+        if (selected_count >= high_count) {
+            selected_count = high_count - 1;
+        }
+
+        ret = measure_prefix(ctx, batch, selected_count, &request_size);
+        if (ret == -1) {
+            flb_free(safe_payload);
+            return -1;
+        }
+        record_count = selected_count;
+    }
 }
 
 static int batch_is_expired(struct flb_az_li *ctx,
@@ -608,9 +848,9 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
 {
     int ret;
     int decoder_result;
-    int crossed_target;
-    size_t last_good_count;
-    size_t selected_count;
+    int expired;
+    size_t minimum_size;
+    size_t midpoint_size;
     size_t next_check;
     size_t file_size;
     size_t request_size;
@@ -636,9 +876,9 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
         return -1;
     }
 
-    crossed_target = FLB_FALSE;
-    last_good_count = 0;
-    next_check = FLB_AZ_LI_BATCH_CHECK_MIN;
+    minimum_size = batch_minimum_size(ctx);
+    midpoint_size = batch_midpoint_size(ctx);
+    next_check = predicted_uncompressed_size(ctx);
 
     mk_list_foreach_safe(head, temporary, &ctx->fs_stream->files) {
         file = mk_list_entry(head, struct flb_fstore_file, _head);
@@ -719,27 +959,40 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
                     return -1;
                 }
 
-                if (request_size >= ctx->batch_size) {
-                    crossed_target = FLB_TRUE;
-                    break;
+                if (request_size > ctx->batch_size) {
+                    flb_log_event_decoder_destroy(&decoder);
+                    flb_free(file_data);
+                    ret = finalize_oversized_batch(ctx, batch,
+                                                   batch->record_count,
+                                                   request_size);
+                    if (ret == -1) {
+                        flb_az_li_batch_destroy(batch);
+                        return -1;
+                    }
+                    return 1;
                 }
 
-                last_good_count = batch->record_count;
-                next_check = flb_sds_len(batch->payload) * 2;
-                if (next_check < flb_sds_len(batch->payload) +
-                                 FLB_AZ_LI_BATCH_CHECK_MIN) {
-                    next_check = flb_sds_len(batch->payload) +
-                                 FLB_AZ_LI_BATCH_CHECK_MIN;
+                if (request_size >= minimum_size) {
+                    flb_log_event_decoder_destroy(&decoder);
+                    flb_free(file_data);
+                    if (finalize_batch(ctx, batch, batch->record_count) == -1) {
+                        flb_az_li_batch_destroy(batch);
+                        return -1;
+                    }
+                    return 1;
+                }
+
+                next_check = project_uncompressed_size(
+                    record_json_size(batch, batch->record_count),
+                    request_size, midpoint_size);
+                if (next_check <= flb_sds_len(batch->payload)) {
+                    next_check = flb_sds_len(batch->payload) + 1;
                 }
             }
         }
 
         flb_log_event_decoder_destroy(&decoder);
         flb_free(file_data);
-
-        if (crossed_target == FLB_TRUE) {
-            break;
-        }
 
         if (decoder_result != FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA) {
             flb_plg_error(ctx->ins, "invalid log data in buffered batch file '%s'",
@@ -760,36 +1013,41 @@ int flb_az_li_batch_prepare(struct flb_az_li *ctx,
         return 0;
     }
 
-    if (crossed_target == FLB_TRUE) {
-        ret = select_record_count(ctx, batch, last_good_count, &selected_count);
-        if (ret == -1 || finalize_batch(ctx, batch, selected_count) == -1) {
+    expired = batch_is_expired(ctx, batch);
+    if (batch->measured_record_count != batch->record_count &&
+        (expired == FLB_TRUE ||
+         ctx->batch_retry_pending == FLB_TRUE ||
+         (ctx->compress_enabled == FLB_TRUE &&
+          flb_sds_len(batch->payload) >= minimum_size &&
+          (ctx->last_probe_generation != ctx->buffer_generation ||
+           flb_sds_len(batch->payload) >
+               ctx->last_probe_uncompressed_size)))) {
+        ret = measure_prefix(ctx, batch, batch->record_count, &request_size);
+        if (ret == -1) {
             flb_az_li_batch_destroy(batch);
             return -1;
         }
-        return 1;
     }
-
-    ret = measure_prefix(ctx, batch, batch->record_count, &request_size);
-    if (ret == -1) {
-        flb_az_li_batch_destroy(batch);
-        return -1;
+    else if (batch->measured_record_count == batch->record_count) {
+        request_size = batch->measured_size;
     }
-
-    if (request_size >= ctx->batch_size) {
-        ret = select_record_count(ctx, batch, last_good_count, &selected_count);
-        if (ret == -1 || finalize_batch(ctx, batch, selected_count) == -1) {
-            flb_az_li_batch_destroy(batch);
-            return -1;
-        }
-        return 1;
-    }
-
-    if (batch_is_expired(ctx, batch) == FLB_FALSE) {
+    else {
         flb_az_li_batch_destroy(batch);
         return 0;
     }
 
-    if (finalize_batch(ctx, batch, batch->record_count) == -1) {
+    if (request_size > ctx->batch_size) {
+        ret = finalize_oversized_batch(ctx, batch, batch->record_count,
+                                       request_size);
+    }
+    else if (request_size >= minimum_size || expired == FLB_TRUE) {
+        ret = finalize_batch(ctx, batch, batch->record_count);
+    }
+    else {
+        flb_az_li_batch_destroy(batch);
+        return 0;
+    }
+    if (ret == -1) {
         flb_az_li_batch_destroy(batch);
         return -1;
     }
@@ -849,6 +1107,12 @@ int flb_az_li_batch_commit(struct flb_az_li *ctx,
 
         index = last_index + 1;
     }
+
+    if (ctx->compress_enabled == FLB_TRUE) {
+        update_average_compression_ratio(ctx, flb_sds_len(batch->payload),
+                                         batch->compressed_size);
+    }
+    ctx->buffer_generation++;
 
     return 0;
 }

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
@@ -345,6 +345,78 @@ static flb_sds_t format_record(struct flb_az_li *ctx,
     return record;
 }
 
+int flb_az_li_batch_format_chunk(struct flb_az_li *ctx,
+                                 const void *data, size_t size,
+                                 flb_sds_t *payload)
+{
+    int ret;
+    int decoder_result;
+    int first_record;
+    flb_sds_t record;
+    flb_sds_t formatted_payload;
+    struct flb_log_event_decoder decoder;
+    struct flb_log_event log_event;
+
+    formatted_payload = flb_sds_create_size(size);
+    if (formatted_payload == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = flb_sds_cat_safe(&formatted_payload, "[", 1);
+    if (ret == -1) {
+        flb_sds_destroy(formatted_payload);
+        return -1;
+    }
+
+    ret = flb_log_event_decoder_init(&decoder, (char *) data, size);
+    if (ret != FLB_EVENT_DECODER_SUCCESS) {
+        flb_sds_destroy(formatted_payload);
+        return -1;
+    }
+
+    first_record = FLB_TRUE;
+    while ((decoder_result = flb_log_event_decoder_next(&decoder, &log_event)) ==
+           FLB_EVENT_DECODER_SUCCESS) {
+        record = format_record(ctx, &log_event);
+        if (record == NULL) {
+            flb_log_event_decoder_destroy(&decoder);
+            flb_sds_destroy(formatted_payload);
+            return -1;
+        }
+
+        if (first_record == FLB_FALSE) {
+            ret = flb_sds_cat_safe(&formatted_payload, ",", 1);
+        }
+        else {
+            ret = 0;
+            first_record = FLB_FALSE;
+        }
+
+        if (ret == 0) {
+            ret = flb_sds_cat_safe(&formatted_payload, record, flb_sds_len(record));
+        }
+        flb_sds_destroy(record);
+
+        if (ret == -1) {
+            flb_log_event_decoder_destroy(&decoder);
+            flb_sds_destroy(formatted_payload);
+            return -1;
+        }
+    }
+
+    flb_log_event_decoder_destroy(&decoder);
+    if (decoder_result != FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA ||
+        flb_sds_cat_safe(&formatted_payload, "]", 1) == -1) {
+        flb_sds_destroy(formatted_payload);
+        return -1;
+    }
+
+    *payload = formatted_payload;
+
+    return 0;
+}
+
 static int batch_record_add(struct flb_az_li_batch *batch,
                             struct flb_fstore_file *file,
                             size_t end_offset)

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
@@ -1,0 +1,799 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_gzip.h>
+#include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_utils.h>
+#include <msgpack.h>
+#include <stdlib.h>
+
+#include "azure_logs_ingestion_batch.h"
+
+#define FLB_AZ_LI_BATCH_CHECK_MIN 65536
+#define FLB_AZ_LI_STORE_META_VERSION 1
+
+struct flb_az_li_store_meta {
+    uint32_t version;
+    uint32_t reserved;
+    uint64_t created;
+    uint64_t offset;
+};
+
+static void normalize_stream_suffix(char *out, size_t out_size, const char *in)
+{
+    size_t index;
+    char character;
+
+    for (index = 0; index < out_size - 1 && in[index] != '\0'; index++) {
+        character = in[index];
+
+        if ((character >= 'a' && character <= 'z') ||
+            (character >= 'A' && character <= 'Z') ||
+            (character >= '0' && character <= '9') ||
+            character == '_' || character == '-' || character == '.') {
+            out[index] = character;
+        }
+        else {
+            out[index] = '_';
+        }
+    }
+
+    out[index] = '\0';
+}
+
+static struct flb_az_li_store_meta *store_meta_get(struct flb_fstore_file *file)
+{
+    struct flb_az_li_store_meta *meta;
+
+    if (file->meta_size != sizeof(struct flb_az_li_store_meta)) {
+        return NULL;
+    }
+
+    meta = file->meta_buf;
+    if (meta == NULL || meta->version != FLB_AZ_LI_STORE_META_VERSION) {
+        return NULL;
+    }
+
+    return meta;
+}
+
+static int store_file_compare(const void *left, const void *right)
+{
+    const struct flb_fstore_file *left_file;
+    const struct flb_fstore_file *right_file;
+
+    left_file = *(const struct flb_fstore_file * const *) left;
+    right_file = *(const struct flb_fstore_file * const *) right;
+
+    return strcmp(left_file->name, right_file->name);
+}
+
+static int store_sort_files(struct flb_az_li *ctx)
+{
+    size_t index;
+    size_t file_count;
+    struct mk_list *head;
+    struct flb_fstore_file **files;
+
+    file_count = mk_list_size(&ctx->fs_stream->files);
+    if (file_count < 2) {
+        return 0;
+    }
+
+    files = flb_malloc(file_count * sizeof(struct flb_fstore_file *));
+    if (files == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    index = 0;
+    mk_list_foreach(head, &ctx->fs_stream->files) {
+        files[index] = mk_list_entry(head, struct flb_fstore_file, _head);
+        index++;
+    }
+
+    qsort(files, file_count, sizeof(struct flb_fstore_file *), store_file_compare);
+
+    for (index = 0; index < file_count; index++) {
+        mk_list_del(&files[index]->_head);
+        mk_list_add(&files[index]->_head, &ctx->fs_stream->files);
+    }
+
+    flb_free(files);
+
+    return 0;
+}
+
+static int store_recover(struct flb_az_li *ctx)
+{
+    ssize_t file_size;
+    struct mk_list *head;
+    struct flb_fstore_file *file;
+    struct flb_az_li_store_meta *meta;
+
+    mk_list_foreach(head, &ctx->fs_stream->files) {
+        file = mk_list_entry(head, struct flb_fstore_file, _head);
+        meta = store_meta_get(file);
+        file_size = cio_chunk_get_content_size(file->chunk);
+
+        if (meta == NULL || file_size < 0 || meta->offset > (size_t) file_size) {
+            flb_plg_error(ctx->ins, "invalid buffered batch file '%s'", file->name);
+            return -1;
+        }
+
+        ctx->buffered_size += (size_t) file_size - meta->offset;
+    }
+
+    return store_sort_files(ctx);
+}
+
+int flb_az_li_batch_init(struct flb_az_li *ctx)
+{
+    const char *instance_name;
+    char stream_suffix[96];
+
+    ctx->fs = flb_fstore_create(ctx->store_dir, FLB_FSTORE_FS);
+    if (ctx->fs == NULL) {
+        return -1;
+    }
+
+    instance_name = ctx->ins->alias ? ctx->ins->alias : ctx->ins->name;
+    normalize_stream_suffix(stream_suffix, sizeof(stream_suffix), instance_name);
+
+    ctx->fs_stream_name = flb_sds_create_size(128);
+    if (ctx->fs_stream_name == NULL) {
+        flb_errno();
+        flb_fstore_destroy(ctx->fs);
+        ctx->fs = NULL;
+        return -1;
+    }
+
+    if (flb_sds_printf(&ctx->fs_stream_name, "azure_logs_ingestion_%s",
+                       stream_suffix) == NULL) {
+        flb_sds_destroy(ctx->fs_stream_name);
+        ctx->fs_stream_name = NULL;
+        flb_fstore_destroy(ctx->fs);
+        ctx->fs = NULL;
+        return -1;
+    }
+
+    ctx->fs_stream = flb_fstore_stream_create(ctx->fs, ctx->fs_stream_name);
+    if (ctx->fs_stream == NULL) {
+        flb_sds_destroy(ctx->fs_stream_name);
+        ctx->fs_stream_name = NULL;
+        flb_fstore_destroy(ctx->fs);
+        ctx->fs = NULL;
+        return -1;
+    }
+
+    if (store_recover(ctx) == -1) {
+        flb_az_li_batch_destroy_context(ctx);
+        return -1;
+    }
+
+    if (ctx->buffered_size > 0) {
+        flb_plg_info(ctx->ins, "recovered %zu buffered bytes", ctx->buffered_size);
+    }
+
+    return 0;
+}
+
+void flb_az_li_batch_destroy_context(struct flb_az_li *ctx)
+{
+    if (ctx->fs_stream_name != NULL) {
+        flb_sds_destroy(ctx->fs_stream_name);
+        ctx->fs_stream_name = NULL;
+    }
+
+    if (ctx->fs != NULL) {
+        flb_fstore_destroy(ctx->fs);
+        ctx->fs = NULL;
+    }
+
+    ctx->fs_stream = NULL;
+}
+
+static flb_sds_t store_file_name(struct flb_az_li *ctx)
+{
+    flb_sds_t name;
+    struct flb_time now;
+
+    flb_time_get(&now);
+
+    name = flb_sds_create_size(96);
+    if (name == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    if (flb_sds_printf(&name, "%" PRIu64 "-%09" PRIu64 "-%" PRIu64 ".flb",
+                       (uint64_t) now.tm.tv_sec,
+                       (uint64_t) now.tm.tv_nsec,
+                       ctx->store_sequence++) == NULL) {
+        flb_sds_destroy(name);
+        return NULL;
+    }
+
+    return name;
+}
+
+int flb_az_li_batch_append(struct flb_az_li *ctx, const void *data, size_t size)
+{
+    int ret;
+    flb_sds_t name;
+    struct flb_fstore_file *file;
+    struct flb_az_li_store_meta meta;
+
+    if (ctx->store_dir_limit_size > 0 &&
+        (ctx->buffered_size > ctx->store_dir_limit_size ||
+         size > ctx->store_dir_limit_size - ctx->buffered_size)) {
+        flb_plg_error(ctx->ins,
+                      "batch buffer is full: buffered=%zu new=%zu limit=%zu",
+                      ctx->buffered_size, size, ctx->store_dir_limit_size);
+        return -1;
+    }
+
+    name = store_file_name(ctx);
+    if (name == NULL) {
+        return -1;
+    }
+
+    file = flb_fstore_file_create(ctx->fs, ctx->fs_stream, name, size);
+    flb_sds_destroy(name);
+    if (file == NULL) {
+        return -1;
+    }
+
+    memset(&meta, 0, sizeof(meta));
+    meta.version = FLB_AZ_LI_STORE_META_VERSION;
+    meta.created = (uint64_t) time(NULL);
+
+    ret = flb_fstore_file_meta_set(ctx->fs, file, &meta, sizeof(meta));
+    if (ret == -1) {
+        flb_fstore_file_delete(ctx->fs, file);
+        return -1;
+    }
+
+    ret = flb_fstore_file_append(file, (void *) data, size);
+    if (ret == -1) {
+        flb_fstore_file_delete(ctx->fs, file);
+        return -1;
+    }
+
+    ctx->buffered_size += size;
+    return 0;
+}
+
+static flb_sds_t format_record(struct flb_az_li *ctx,
+                               struct flb_log_event *log_event)
+{
+    int index;
+    int length;
+    size_t size;
+    double timestamp;
+    struct tm time_value;
+    struct flb_time event_time;
+    msgpack_object map;
+    msgpack_sbuffer buffer;
+    msgpack_packer packer;
+    flb_sds_t record;
+    char formatted_time[32];
+
+    if (log_event->body == NULL || log_event->body->type != MSGPACK_OBJECT_MAP) {
+        flb_plg_error(ctx->ins, "log event body is not a map");
+        return NULL;
+    }
+
+    map = *log_event->body;
+    flb_time_copy(&event_time, &log_event->timestamp);
+    msgpack_sbuffer_init(&buffer);
+    msgpack_packer_init(&packer, &buffer, msgpack_sbuffer_write);
+    msgpack_pack_map(&packer, map.via.map.size + 1);
+
+    msgpack_pack_str(&packer, flb_sds_len(ctx->time_key));
+    msgpack_pack_str_body(&packer, ctx->time_key, flb_sds_len(ctx->time_key));
+
+    if (ctx->time_generated == FLB_TRUE) {
+        gmtime_r(&event_time.tm.tv_sec, &time_value);
+        size = strftime(formatted_time, sizeof(formatted_time) - 1,
+                        FLB_PACK_JSON_DATE_ISO8601_FMT, &time_value);
+        length = snprintf(formatted_time + size,
+                          sizeof(formatted_time) - size,
+                          ".%03" PRIu64 "Z",
+                          (uint64_t) event_time.tm.tv_nsec / 1000000);
+        if (length < 0 || (size_t) length >= sizeof(formatted_time) - size) {
+            msgpack_sbuffer_destroy(&buffer);
+            return NULL;
+        }
+        size += length;
+        msgpack_pack_str(&packer, size);
+        msgpack_pack_str_body(&packer, formatted_time, size);
+    }
+    else {
+        timestamp = flb_time_to_double(&event_time);
+        msgpack_pack_double(&packer, timestamp);
+    }
+
+    for (index = 0; index < map.via.map.size; index++) {
+        msgpack_pack_object(&packer, map.via.map.ptr[index].key);
+        msgpack_pack_object(&packer, map.via.map.ptr[index].val);
+    }
+
+    record = flb_msgpack_raw_to_json_sds(buffer.data, buffer.size,
+                                         ctx->config->json_escape_unicode);
+    msgpack_sbuffer_destroy(&buffer);
+
+    return record;
+}
+
+static int batch_record_add(struct flb_az_li_batch *batch,
+                            struct flb_fstore_file *file,
+                            size_t end_offset)
+{
+    size_t capacity;
+    struct flb_az_li_batch_record *records;
+
+    if (batch->record_count == batch->record_capacity) {
+        capacity = batch->record_capacity == 0 ? 128 : batch->record_capacity * 2;
+        records = flb_realloc(batch->records,
+                              capacity * sizeof(struct flb_az_li_batch_record));
+        if (records == NULL) {
+            flb_errno();
+            return -1;
+        }
+
+        batch->records = records;
+        batch->record_capacity = capacity;
+    }
+
+    batch->records[batch->record_count].file = file;
+    batch->records[batch->record_count].end_offset = end_offset;
+    batch->records[batch->record_count].json_end = flb_sds_len(batch->payload);
+    batch->record_count++;
+
+    return 0;
+}
+
+static int compress_prefix(struct flb_az_li_batch *batch, size_t record_count,
+                           void **compressed_payload, size_t *compressed_size)
+{
+    int ret;
+    size_t json_end;
+    char saved_character;
+
+    json_end = batch->records[record_count - 1].json_end;
+    saved_character = batch->payload[json_end];
+    batch->payload[json_end] = ']';
+
+    ret = flb_gzip_compress(batch->payload, json_end + 1,
+                            compressed_payload, compressed_size);
+    batch->payload[json_end] = saved_character;
+
+    return ret;
+}
+
+static int measure_prefix(struct flb_az_li *ctx,
+                          struct flb_az_li_batch *batch,
+                          size_t record_count,
+                          size_t *request_size)
+{
+    int ret;
+    size_t json_end;
+    void *compressed_payload;
+
+    json_end = batch->records[record_count - 1].json_end;
+    if (ctx->compress_enabled == FLB_FALSE) {
+        *request_size = json_end + 1;
+        return 0;
+    }
+
+    compressed_payload = NULL;
+    ret = compress_prefix(batch, record_count, &compressed_payload, request_size);
+    if (ret == -1) {
+        return -1;
+    }
+
+    flb_free(compressed_payload);
+
+    return 0;
+}
+
+static int select_record_count(struct flb_az_li *ctx,
+                               struct flb_az_li_batch *batch,
+                               size_t last_good_count,
+                               size_t *selected_count)
+{
+    int ret;
+    size_t low;
+    size_t high;
+    size_t middle;
+    size_t request_size;
+
+    low = last_good_count;
+    high = batch->record_count;
+
+    while (low < high) {
+        middle = low + (high - low + 1) / 2;
+
+        ret = measure_prefix(ctx, batch, middle, &request_size);
+        if (ret == -1) {
+            return -1;
+        }
+
+        if (request_size <= ctx->batch_size) {
+            low = middle;
+        }
+        else {
+            high = middle - 1;
+        }
+    }
+
+    if (low == 0) {
+        low = 1;
+    }
+
+    *selected_count = low;
+    return 0;
+}
+
+static int finalize_batch(struct flb_az_li *ctx,
+                          struct flb_az_li_batch *batch,
+                          size_t selected_count)
+{
+    int ret;
+    size_t json_end;
+    size_t request_size;
+
+    json_end = batch->records[selected_count - 1].json_end;
+    flb_sds_len_set(batch->payload, json_end);
+    batch->payload[json_end] = '\0';
+
+    ret = flb_sds_cat_safe(&batch->payload, "]", 1);
+    if (ret == -1) {
+        return -1;
+    }
+
+    batch->record_count = selected_count;
+    request_size = flb_sds_len(batch->payload);
+
+    if (ctx->compress_enabled == FLB_TRUE) {
+        ret = flb_gzip_compress(batch->payload, flb_sds_len(batch->payload),
+                                &batch->compressed_payload, &batch->compressed_size);
+        if (ret == -1) {
+            return -1;
+        }
+        request_size = batch->compressed_size;
+    }
+
+    if (selected_count == 1 && request_size > ctx->batch_size) {
+        flb_plg_warn(ctx->ins,
+                     "single log record exceeds the batch target: "
+                     "bytes=%zu target=%zu",
+                     request_size, ctx->batch_size);
+    }
+
+    return 0;
+}
+
+static int batch_is_expired(struct flb_az_li *ctx,
+                            struct flb_az_li_batch *batch)
+{
+    struct flb_az_li_store_meta *meta;
+
+    meta = store_meta_get(batch->records[0].file);
+    if (meta == NULL) {
+        return FLB_FALSE;
+    }
+
+    if ((uint64_t) time(NULL) >= meta->created + (uint64_t) ctx->batch_timeout) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+static void discard_corrupt_file(struct flb_az_li *ctx,
+                                struct flb_fstore_file *file,
+                                size_t file_size,
+                                size_t offset)
+{
+    size_t pending_size;
+
+    pending_size = file_size - offset;
+    if (pending_size <= ctx->buffered_size) {
+        ctx->buffered_size -= pending_size;
+    }
+    else {
+        ctx->buffered_size = 0;
+    }
+
+    flb_plg_error(ctx->ins, "discarding corrupt buffered batch file '%s'",
+                  file->name);
+    flb_fstore_file_delete(ctx->fs, file);
+}
+
+int flb_az_li_batch_prepare(struct flb_az_li *ctx,
+                            struct flb_az_li_batch *batch)
+{
+    int ret;
+    int decoder_result;
+    int crossed_target;
+    size_t last_good_count;
+    size_t selected_count;
+    size_t next_check;
+    size_t file_size;
+    size_t request_size;
+    void *file_data;
+    flb_sds_t record;
+    struct mk_list *head;
+    struct mk_list *temporary;
+    struct flb_fstore_file *file;
+    struct flb_az_li_store_meta *meta;
+    struct flb_log_event_decoder decoder;
+    struct flb_log_event log_event;
+
+    memset(batch, 0, sizeof(struct flb_az_li_batch));
+    batch->payload = flb_sds_create_size(ctx->batch_size + 1);
+    if (batch->payload == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = flb_sds_cat_safe(&batch->payload, "[", 1);
+    if (ret == -1) {
+        flb_az_li_batch_destroy(batch);
+        return -1;
+    }
+
+    crossed_target = FLB_FALSE;
+    last_good_count = 0;
+    next_check = FLB_AZ_LI_BATCH_CHECK_MIN;
+
+    mk_list_foreach_safe(head, temporary, &ctx->fs_stream->files) {
+        file = mk_list_entry(head, struct flb_fstore_file, _head);
+        meta = store_meta_get(file);
+        if (meta == NULL) {
+            flb_plg_error(ctx->ins, "invalid buffered batch metadata in '%s'",
+                          file->name);
+            flb_az_li_batch_destroy(batch);
+            return -1;
+        }
+
+        file_data = NULL;
+        file_size = 0;
+        ret = flb_fstore_file_content_copy(ctx->fs, file, &file_data, &file_size);
+        if (ret == -1 || meta->offset > file_size) {
+            flb_plg_error(ctx->ins, "cannot read buffered batch file '%s'",
+                          file->name);
+            flb_free(file_data);
+            flb_az_li_batch_destroy(batch);
+            return -1;
+        }
+
+        if (meta->offset == file_size) {
+            flb_free(file_data);
+            flb_fstore_file_delete(ctx->fs, file);
+            continue;
+        }
+
+        ret = flb_log_event_decoder_init(&decoder,
+                                         (char *) file_data + meta->offset,
+                                         file_size - meta->offset);
+        if (ret != FLB_EVENT_DECODER_SUCCESS) {
+            flb_free(file_data);
+            discard_corrupt_file(ctx, file, file_size, meta->offset);
+            flb_az_li_batch_destroy(batch);
+            return FLB_AZ_LI_BATCH_CORRUPT_FILE;
+        }
+
+        while ((decoder_result = flb_log_event_decoder_next(&decoder, &log_event)) ==
+               FLB_EVENT_DECODER_SUCCESS) {
+            record = format_record(ctx, &log_event);
+            if (record == NULL) {
+                flb_log_event_decoder_destroy(&decoder);
+                flb_free(file_data);
+                discard_corrupt_file(ctx, file, file_size, meta->offset);
+                flb_az_li_batch_destroy(batch);
+                return FLB_AZ_LI_BATCH_CORRUPT_FILE;
+            }
+
+            if (batch->record_count > 0) {
+                ret = flb_sds_cat_safe(&batch->payload, ",", 1);
+                if (ret == -1) {
+                    flb_sds_destroy(record);
+                    flb_log_event_decoder_destroy(&decoder);
+                    flb_free(file_data);
+                    flb_az_li_batch_destroy(batch);
+                    return -1;
+                }
+            }
+
+            ret = flb_sds_cat_safe(&batch->payload, record, flb_sds_len(record));
+            flb_sds_destroy(record);
+            if (ret == -1 ||
+                batch_record_add(batch, file,
+                                 meta->offset + decoder.offset) == -1) {
+                flb_log_event_decoder_destroy(&decoder);
+                flb_free(file_data);
+                flb_az_li_batch_destroy(batch);
+                return -1;
+            }
+
+            if (flb_sds_len(batch->payload) >= next_check) {
+                ret = measure_prefix(ctx, batch, batch->record_count, &request_size);
+                if (ret == -1) {
+                    flb_log_event_decoder_destroy(&decoder);
+                    flb_free(file_data);
+                    flb_az_li_batch_destroy(batch);
+                    return -1;
+                }
+
+                if (request_size >= ctx->batch_size) {
+                    crossed_target = FLB_TRUE;
+                    break;
+                }
+
+                last_good_count = batch->record_count;
+                next_check = flb_sds_len(batch->payload) * 2;
+                if (next_check < flb_sds_len(batch->payload) +
+                                 FLB_AZ_LI_BATCH_CHECK_MIN) {
+                    next_check = flb_sds_len(batch->payload) +
+                                 FLB_AZ_LI_BATCH_CHECK_MIN;
+                }
+            }
+        }
+
+        flb_log_event_decoder_destroy(&decoder);
+        flb_free(file_data);
+
+        if (crossed_target == FLB_TRUE) {
+            break;
+        }
+
+        if (decoder_result != FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA) {
+            flb_plg_error(ctx->ins, "invalid log data in buffered batch file '%s'",
+                          file->name);
+            discard_corrupt_file(ctx, file, file_size, meta->offset);
+            flb_az_li_batch_destroy(batch);
+            return FLB_AZ_LI_BATCH_CORRUPT_FILE;
+        }
+
+        if (batch->record_count == 0) {
+            ctx->buffered_size -= file_size - meta->offset;
+            flb_fstore_file_delete(ctx->fs, file);
+        }
+    }
+
+    if (batch->record_count == 0) {
+        flb_az_li_batch_destroy(batch);
+        return 0;
+    }
+
+    if (crossed_target == FLB_TRUE) {
+        ret = select_record_count(ctx, batch, last_good_count, &selected_count);
+        if (ret == -1 || finalize_batch(ctx, batch, selected_count) == -1) {
+            flb_az_li_batch_destroy(batch);
+            return -1;
+        }
+        return 1;
+    }
+
+    ret = measure_prefix(ctx, batch, batch->record_count, &request_size);
+    if (ret == -1) {
+        flb_az_li_batch_destroy(batch);
+        return -1;
+    }
+
+    if (request_size >= ctx->batch_size) {
+        ret = select_record_count(ctx, batch, last_good_count, &selected_count);
+        if (ret == -1 || finalize_batch(ctx, batch, selected_count) == -1) {
+            flb_az_li_batch_destroy(batch);
+            return -1;
+        }
+        return 1;
+    }
+
+    if (batch_is_expired(ctx, batch) == FLB_FALSE) {
+        flb_az_li_batch_destroy(batch);
+        return 0;
+    }
+
+    if (finalize_batch(ctx, batch, batch->record_count) == -1) {
+        flb_az_li_batch_destroy(batch);
+        return -1;
+    }
+
+    return 1;
+}
+
+int flb_az_li_batch_commit(struct flb_az_li *ctx,
+                           struct flb_az_li_batch *batch)
+{
+    int ret;
+    size_t index;
+    size_t last_index;
+    size_t file_size;
+    size_t previous_offset;
+    struct flb_fstore_file *file;
+    struct flb_az_li_store_meta meta;
+    struct flb_az_li_store_meta *stored_meta;
+
+    index = 0;
+
+    while (index < batch->record_count) {
+        file = batch->records[index].file;
+        last_index = index;
+
+        while (last_index + 1 < batch->record_count &&
+               batch->records[last_index + 1].file == file) {
+            last_index++;
+        }
+
+        stored_meta = store_meta_get(file);
+        if (stored_meta == NULL) {
+            return -1;
+        }
+
+        meta = *stored_meta;
+        previous_offset = meta.offset;
+        meta.offset = batch->records[last_index].end_offset;
+
+        ret = flb_fstore_file_meta_set(ctx->fs, file, &meta, sizeof(meta));
+        if (ret == -1) {
+            return -1;
+        }
+
+        if (meta.offset >= previous_offset &&
+            meta.offset - previous_offset <= ctx->buffered_size) {
+            ctx->buffered_size -= meta.offset - previous_offset;
+        }
+        else {
+            ctx->buffered_size = 0;
+        }
+
+        file_size = cio_chunk_get_content_size(file->chunk);
+        if (meta.offset >= file_size) {
+            flb_fstore_file_delete(ctx->fs, file);
+        }
+
+        index = last_index + 1;
+    }
+
+    return 0;
+}
+
+void flb_az_li_batch_destroy(struct flb_az_li_batch *batch)
+{
+    if (batch->payload != NULL) {
+        flb_sds_destroy(batch->payload);
+    }
+
+    if (batch->compressed_payload != NULL) {
+        flb_free(batch->compressed_payload);
+    }
+
+    if (batch->records != NULL) {
+        flb_free(batch->records);
+    }
+
+    memset(batch, 0, sizeof(struct flb_az_li_batch));
+}

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
@@ -41,6 +41,9 @@ struct flb_az_li_batch {
 
 int flb_az_li_batch_init(struct flb_az_li *ctx);
 void flb_az_li_batch_destroy_context(struct flb_az_li *ctx);
+int flb_az_li_batch_format_chunk(struct flb_az_li *ctx,
+                                 const void *data, size_t size,
+                                 flb_sds_t *payload);
 int flb_az_li_batch_append(struct flb_az_li *ctx, const void *data, size_t size);
 int flb_az_li_batch_prepare(struct flb_az_li *ctx,
                             struct flb_az_li_batch *batch);

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
@@ -44,6 +44,9 @@ struct flb_az_li_batch {
 
 int flb_az_li_batch_init(struct flb_az_li *ctx);
 void flb_az_li_batch_destroy_context(struct flb_az_li *ctx);
+int flb_az_li_gzip_compress(struct flb_az_li *ctx,
+                            void *in_data, size_t in_len,
+                            void **out_data, size_t *out_len);
 int flb_az_li_batch_format_chunk(struct flb_az_li *ctx,
                                  const void *data, size_t size,
                                  flb_sds_t *payload);

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
@@ -34,6 +34,9 @@ struct flb_az_li_batch {
     flb_sds_t payload;
     void *compressed_payload;
     size_t compressed_size;
+    size_t measured_record_count;
+    size_t measured_size;
+    size_t gzip_operations;
     struct flb_az_li_batch_record *records;
     size_t record_count;
     size_t record_capacity;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
@@ -1,0 +1,51 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_OUT_AZURE_LOGS_INGESTION_BATCH_H
+#define FLB_OUT_AZURE_LOGS_INGESTION_BATCH_H
+
+#include "azure_logs_ingestion.h"
+
+#define FLB_AZ_LI_BATCH_CORRUPT_FILE -2
+
+struct flb_az_li_batch_record {
+    struct flb_fstore_file *file;
+    size_t end_offset;
+    size_t json_end;
+};
+
+struct flb_az_li_batch {
+    flb_sds_t payload;
+    void *compressed_payload;
+    size_t compressed_size;
+    struct flb_az_li_batch_record *records;
+    size_t record_count;
+    size_t record_capacity;
+};
+
+int flb_az_li_batch_init(struct flb_az_li *ctx);
+void flb_az_li_batch_destroy_context(struct flb_az_li *ctx);
+int flb_az_li_batch_append(struct flb_az_li *ctx, const void *data, size_t size);
+int flb_az_li_batch_prepare(struct flb_az_li *ctx,
+                            struct flb_az_li_batch *batch);
+int flb_az_li_batch_commit(struct flb_az_li *ctx,
+                           struct flb_az_li_batch *batch);
+void flb_az_li_batch_destroy(struct flb_az_li_batch *batch);
+
+#endif

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_oauth2.h>
 
 #include "azure_logs_ingestion.h"
+#include "azure_logs_ingestion_batch.h"
 #include "azure_logs_ingestion_conf.h"
 
 static int validate_auth_url_override(struct flb_output_instance *ins,
@@ -95,6 +96,21 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         return NULL;
     }
 
+    ret = pthread_mutex_init(&ctx->token_mutex, NULL);
+    if (ret != 0) {
+        flb_free(ctx);
+        return NULL;
+    }
+    ctx->token_mutex_initialized = FLB_TRUE;
+
+    ret = pthread_mutex_init(&ctx->batch_mutex, NULL);
+    if (ret != 0) {
+        pthread_mutex_destroy(&ctx->token_mutex);
+        flb_free(ctx);
+        return NULL;
+    }
+    ctx->batch_mutex_initialized = FLB_TRUE;
+
     /* Set the conext in output_instance so that we can retrieve it later */
     ctx->ins = ins;
     ctx->config = config;
@@ -105,6 +121,7 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     ret = flb_output_config_map_set(ins, (void *) ctx);
     if (ret == -1) {
         flb_plg_error(ins, "unable to load configuration");
+        flb_az_li_ctx_destroy(ctx);
         return NULL;
     }
 
@@ -141,6 +158,16 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     /* config: 'table_name' */
     if (!ctx->table_name) {
         flb_plg_error(ins, "property 'table_name' is not defined");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+    if (ctx->batch_size == 0) {
+        flb_plg_error(ins, "property 'batch_size' must be greater than zero");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+    if (ctx->batch_timeout <= 0) {
+        flb_plg_error(ins, "property 'batch_timeout' must be greater than zero");
         flb_az_li_ctx_destroy(ctx);
         return NULL;
     }
@@ -186,9 +213,6 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
                     FLB_AZ_LI_DCE_URL_TMPLT, ctx->dce_url, 
                     ctx->dcr_id, ctx->table_name);
 
-    /* Initialize the auth mutex */
-    pthread_mutex_init(&ctx->token_mutex, NULL);
-
     /* Create oauth2 context */
     ctx->u_auth = flb_oauth2_create(config, ctx->auth_url,
                                     FLB_AZ_LI_TOKEN_TIMEOUT);
@@ -207,6 +231,14 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         return NULL;
     }
     flb_output_upstream_set(ctx->u_dce, ins);
+
+    ret = flb_az_li_batch_init(ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "cannot initialize batch storage at '%s'",
+                      ctx->store_dir);
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
 
     flb_plg_info(ins, "dce_url='%s', dcr='%s', table='%s', stream='Custom-%s'",
                 ctx->dce_url, ctx->dcr_id, ctx->table_name, ctx->table_name);
@@ -236,6 +268,17 @@ int flb_az_li_ctx_destroy(struct flb_az_li *ctx)
     if (ctx->u_dce) {
         flb_upstream_destroy(ctx->u_dce);
     }
+
+    flb_az_li_batch_destroy_context(ctx);
+
+    if (ctx->batch_mutex_initialized == FLB_TRUE) {
+        pthread_mutex_destroy(&ctx->batch_mutex);
+    }
+
+    if (ctx->token_mutex_initialized == FLB_TRUE) {
+        pthread_mutex_destroy(&ctx->token_mutex);
+    }
+
     flb_free(ctx);
 
     return 0;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -161,15 +161,17 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         flb_az_li_ctx_destroy(ctx);
         return NULL;
     }
-    if (ctx->batch_size == 0) {
-        flb_plg_error(ins, "property 'batch_size' must be greater than zero");
-        flb_az_li_ctx_destroy(ctx);
-        return NULL;
-    }
-    if (ctx->batch_timeout <= 0) {
-        flb_plg_error(ins, "property 'batch_timeout' must be greater than zero");
-        flb_az_li_ctx_destroy(ctx);
-        return NULL;
+    if (ctx->batching_enabled == FLB_TRUE) {
+        if (ctx->batch_size == 0) {
+            flb_plg_error(ins, "property 'batch_size' must be greater than zero");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->batch_timeout <= 0) {
+            flb_plg_error(ins, "property 'batch_timeout' must be greater than zero");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
     }
 
     if (ctx->auth_url_override) {
@@ -232,12 +234,14 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     }
     flb_output_upstream_set(ctx->u_dce, ins);
 
-    ret = flb_az_li_batch_init(ctx);
-    if (ret == -1) {
-        flb_plg_error(ins, "cannot initialize batch storage at '%s'",
-                      ctx->store_dir);
-        flb_az_li_ctx_destroy(ctx);
-        return NULL;
+    if (ctx->batching_enabled == FLB_TRUE) {
+        ret = flb_az_li_batch_init(ctx);
+        if (ret == -1) {
+            flb_plg_error(ins, "cannot initialize batch storage at '%s'",
+                          ctx->store_dir);
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
     }
 
     flb_plg_info(ins, "dce_url='%s', dcr='%s', table='%s', stream='Custom-%s'",

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -244,6 +244,24 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         }
     }
 
+#ifdef FLB_HAVE_METRICS
+    ctx->cmt_compression_ratio = cmt_gauge_create(
+        ins->cmt,
+        "fluentbit",
+        "azure_logs_ingestion",
+        "compression_ratio",
+        "Adaptive average ratio of uncompressed JSON bytes to gzip bytes.",
+        1, (char *[]) {"name"});
+    if (ctx->cmt_compression_ratio == NULL) {
+        flb_plg_error(ins, "cannot create compression ratio metric");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+
+    cmt_gauge_set(ctx->cmt_compression_ratio, cfl_time_now(), 0,
+                 1, (char *[]) {(char *) flb_output_name(ins)});
+#endif
+
     flb_plg_info(ins, "dce_url='%s', dcr='%s', table='%s', stream='Custom-%s'",
                 ctx->dce_url, ctx->dcr_id, ctx->table_name, ctx->table_name);
 

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -162,8 +162,22 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         return NULL;
     }
     if (ctx->buffering_enabled == FLB_TRUE) {
-        if (ctx->batch_size == 0) {
-            flb_plg_error(ins, "property 'batch_size' must be greater than zero");
+        if (ctx->max_batch_size == 0) {
+            flb_plg_error(ins,
+                          "property 'max_batch_size' must be greater than zero");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->min_batch_size == 0) {
+            flb_plg_error(ins,
+                          "property 'min_batch_size' must be greater than zero");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->min_batch_size > ctx->max_batch_size) {
+            flb_plg_error(ins,
+                          "property 'min_batch_size' must not exceed "
+                          "'max_batch_size'");
             flb_az_li_ctx_destroy(ctx);
             return NULL;
         }
@@ -260,6 +274,22 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
 
     cmt_gauge_set(ctx->cmt_compression_ratio, cfl_time_now(), 0,
                  1, (char *[]) {(char *) flb_output_name(ins)});
+
+    ctx->cmt_gzip_operations = cmt_counter_create(
+        ins->cmt,
+        "fluentbit",
+        "azure_logs_ingestion",
+        "gzip_operations_total",
+        "Total number of gzip operations performed.",
+        1, (char *[]) {"name"});
+    if (ctx->cmt_gzip_operations == NULL) {
+        flb_plg_error(ins, "cannot create gzip operations metric");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+
+    cmt_counter_set(ctx->cmt_gzip_operations, cfl_time_now(), 0,
+                   1, (char *[]) {(char *) flb_output_name(ins)});
 #endif
 
     flb_plg_info(ins, "dce_url='%s', dcr='%s', table='%s', stream='Custom-%s'",

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -161,7 +161,7 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         flb_az_li_ctx_destroy(ctx);
         return NULL;
     }
-    if (ctx->batching_enabled == FLB_TRUE) {
+    if (ctx->buffering_enabled == FLB_TRUE) {
         if (ctx->batch_size == 0) {
             flb_plg_error(ins, "property 'batch_size' must be greater than zero");
             flb_az_li_ctx_destroy(ctx);
@@ -234,7 +234,7 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     }
     flb_output_upstream_set(ctx->u_dce, ins);
 
-    if (ctx->batching_enabled == FLB_TRUE) {
+    if (ctx->buffering_enabled == FLB_TRUE) {
         ret = flb_az_li_batch_init(ctx);
         if (ret == -1) {
             flb_plg_error(ins, "cannot initialize batch storage at '%s'",

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
@@ -23,7 +23,7 @@ pipeline:
       dcr_id: dcr-suite
       table_name: suite_CL
       compress: on
-      batching_enabled: on
+      buffering_enabled: on
       batch_size: 175
       batch_timeout: 3s
       store_dir: ${AZURE_LOGS_INGESTION_STORE_DIR}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
@@ -23,6 +23,7 @@ pipeline:
       dcr_id: dcr-suite
       table_name: suite_CL
       compress: on
+      batching_enabled: on
       batch_size: 175
       batch_timeout: 3s
       store_dir: ${AZURE_LOGS_INGESTION_STORE_DIR}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
@@ -24,7 +24,8 @@ pipeline:
       table_name: suite_CL
       compress: on
       buffering_enabled: on
-      batch_size: 175
+      max_batch_size: 175
+      min_batch_size: 122
       batch_timeout: 5s
       store_dir: ${AZURE_LOGS_INGESTION_STORE_DIR}
       tls.verify: on

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
@@ -6,10 +6,11 @@ service:
 
 pipeline:
   inputs:
-    - name: dummy
+    - name: http
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
       tag: azure_logs_ingestion
-      dummy: '{"message":"hello from azure logs ingestion","source":"dummy","level":"info"}'
-      samples: 1
+      enable_health_endpoint: on
 
   outputs:
     - name: azure_logs_ingestion
@@ -22,7 +23,8 @@ pipeline:
       dcr_id: dcr-suite
       table_name: suite_CL
       compress: on
-      batch_timeout: 1s
+      batch_size: 175
+      batch_timeout: 3s
       store_dir: ${AZURE_LOGS_INGESTION_STORE_DIR}
       tls.verify: on
       tls.verify_hostname: on

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_batching.yaml
@@ -1,6 +1,6 @@
 service:
   flush: 1
-  log_level: info
+  log_level: debug
   http_server: on
   http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
 
@@ -25,7 +25,7 @@ pipeline:
       compress: on
       buffering_enabled: on
       batch_size: 175
-      batch_timeout: 3s
+      batch_timeout: 5s
       store_dir: ${AZURE_LOGS_INGESTION_STORE_DIR}
       tls.verify: on
       tls.verify_hostname: on

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_oauth2.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_oauth2.yaml
@@ -22,8 +22,6 @@ pipeline:
       dcr_id: dcr-suite
       table_name: suite_CL
       compress: on
-      batch_timeout: 1s
-      store_dir: ${AZURE_LOGS_INGESTION_STORE_DIR}
       tls.verify: on
       tls.verify_hostname: on
       tls.vhost: localhost

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -18,6 +18,12 @@ from utils.test_service import FluentBitTestService
 
 logger = logging.getLogger(__name__)
 
+MAX_BATCH_SIZE = 175
+MIN_BATCH_SIZE = 122
+TARGET_BATCH_SIZE = MIN_BATCH_SIZE + (
+    (MAX_BATCH_SIZE - MIN_BATCH_SIZE) * 90 // 100
+)
+
 
 class Service:
     def __init__(self, config_file):
@@ -148,6 +154,15 @@ class Service:
             for record_count, request_size, gzip_operations in matches
         ]
 
+    def prometheus_metrics(self):
+        response = requests.get(
+            f"http://127.0.0.1:{self.flb.http_monitoring_port}"
+            "/api/v2/metrics/prometheus",
+            timeout=5,
+        )
+        response.raise_for_status()
+        return response.text
+
     def send_log(self, message):
         response = requests.post(
             f"http://127.0.0.1:{self.flb_listener_port}/azure_logs_ingestion",
@@ -167,6 +182,25 @@ def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
     )
 
     requests_seen = service.wait_for_requests(2, timeout=15)
+
+    def immediate_gzip_operations():
+        metrics = service.prometheus_metrics()
+        match = re.search(
+            r'fluentbit_azure_logs_ingestion_gzip_operations_total'
+            r'\{[^}]*name="azure_logs_ingestion\.0"[^}]*\}\s+([0-9.eE+-]+)',
+            metrics,
+        )
+        if match is not None and int(float(match.group(1))) == 1:
+            return 1
+
+        return None
+
+    gzip_operations = service.service.wait_for_condition(
+        immediate_gzip_operations,
+        timeout=5,
+        interval=0.25,
+        description="one immediate Azure Logs Ingestion gzip operation",
+    )
     service.stop()
 
     token_request = next(request for request in requests_seen if request["path"] == "/oauth/token")
@@ -195,6 +229,7 @@ def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
     assert payload[0]["source"] == "dummy"
     assert payload[0]["level"] == "info"
     assert isinstance(payload[0]["@timestamp"], (int, float))
+    assert gzip_operations == 1
 
 
 def test_out_azure_logs_ingestion_batches_by_compressed_size_and_timeout():
@@ -237,7 +272,11 @@ def test_out_azure_logs_ingestion_batches_by_compressed_size_and_timeout():
 
     assert 1 < len(first_batch["json"]) < len(messages)
     assert first_batch["headers"].get("Content-Encoding") == "gzip"
-    assert 122 <= int(first_batch["headers"]["Content-Length"]) <= 175
+    assert (
+        MIN_BATCH_SIZE <=
+        int(first_batch["headers"]["Content-Length"]) <=
+        MAX_BATCH_SIZE
+    )
 
     service.service.wait_for_condition(
         lambda: service.data_requests()
@@ -273,52 +312,69 @@ def test_out_azure_logs_ingestion_batches_by_compressed_size_and_timeout():
     for observed_ratio in observed_ratios[1:]:
         expected_ratio = expected_ratio * 0.75 + observed_ratio * 0.25
 
-    def compression_ratio_metric():
-        response = requests.get(
-            f"http://127.0.0.1:{service.flb.http_monitoring_port}"
-            "/api/v2/metrics/prometheus",
-            timeout=5,
-        )
-        response.raise_for_status()
+    batch_preparations = service.batch_preparations()
+    expected_gzip_operations = sum(
+        preparation["gzip_operations"] for preparation in batch_preparations
+    )
+
+    def compression_metrics():
+        metrics = service.prometheus_metrics()
         match = re.search(
             r'fluentbit_azure_logs_ingestion_compression_ratio'
             r'\{[^}]*name="azure_logs_ingestion\.0"[^}]*\}\s+([0-9.eE+-]+)',
-            response.text,
+            metrics,
         )
         if match is None:
             return None
 
-        ratio = float(match.group(1))
-        return ratio if math.isclose(ratio, expected_ratio, rel_tol=1e-6) else None
+        gzip_match = re.search(
+            r'fluentbit_azure_logs_ingestion_gzip_operations_total'
+            r'\{[^}]*name="azure_logs_ingestion\.0"[^}]*\}\s+([0-9.eE+-]+)',
+            metrics,
+        )
+        if gzip_match is None:
+            return None
 
-    compression_ratio = service.service.wait_for_condition(
-        compression_ratio_metric,
+        ratio = float(match.group(1))
+        gzip_operations = int(float(gzip_match.group(1)))
+        if (math.isclose(ratio, expected_ratio, rel_tol=1e-6) and
+                gzip_operations == expected_gzip_operations):
+            return ratio, gzip_operations
+
+        return None
+
+    compression_ratio, gzip_operations = service.service.wait_for_condition(
+        compression_metrics,
         timeout=5,
         interval=0.25,
-        description="the Azure Logs Ingestion compression ratio metric",
+        description="the Azure Logs Ingestion compression metrics",
     )
     assert compression_ratio > 1
+    assert gzip_operations > 0
 
-    batch_preparations = service.batch_preparations()
     service.stop()
 
     full_batches = [
         preparation
         for preparation in batch_preparations
-        if preparation["bytes"] >= 122
+        if preparation["bytes"] >= MIN_BATCH_SIZE
     ]
     assert len(full_batches) >= 3
-    assert all(preparation["bytes"] <= 175 for preparation in full_batches)
-    assert 130 <= (
-        sum(preparation["bytes"] for preparation in full_batches) /
-        len(full_batches)
-    ) <= 166
+    assert all(
+        preparation["bytes"] <= MAX_BATCH_SIZE
+        for preparation in full_batches
+    )
+    steady_batch_average = (
+        sum(preparation["bytes"] for preparation in full_batches[2:]) /
+        len(full_batches[2:])
+    )
+    assert abs(steady_batch_average - TARGET_BATCH_SIZE) <= 10
     assert (
         sum(preparation["gzip_operations"] for preparation in full_batches) /
         len(full_batches)
     ) < 2
     assert len(batch_preparations) == len(requests_seen)
-    assert batch_preparations[-1]["bytes"] < 122
+    assert batch_preparations[-1]["bytes"] < MIN_BATCH_SIZE
     assert batch_preparations[-1]["records"] == 1
 
     received_messages = [

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1,5 +1,8 @@
 import logging
 import os
+import shutil
+import tempfile
+import time
 
 import requests
 
@@ -20,6 +23,7 @@ class Service:
         cert_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate"))
         self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
         self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
+        self.store_dir = tempfile.mkdtemp(prefix="fluent-bit-azure-logs-ingestion-")
         self.oauth_server_port = None
         self.service = FluentBitTestService(
             self.config_file,
@@ -28,6 +32,7 @@ class Service:
             extra_env={
                 "CERTIFICATE_TEST": self.tls_crt_file,
                 "PRIVATE_KEY_TEST": self.tls_key_file,
+                "AZURE_LOGS_INGESTION_STORE_DIR": self.store_dir,
             },
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
@@ -98,6 +103,8 @@ class Service:
         except requests.RequestException:
             pass
 
+        shutil.rmtree(self.store_dir, ignore_errors=True)
+
     def start(self):
         self.service.start()
         self.flb = self.service.flb
@@ -114,6 +121,21 @@ class Service:
             interval=0.5,
             description=f"{minimum_count} azure logs ingestion requests",
         )
+
+    def data_requests(self):
+        return [
+            request
+            for request in data_storage["requests"]
+            if request["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
+        ]
+
+    def send_log(self, message):
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/azure_logs_ingestion",
+            json={"message": message},
+            timeout=5,
+        )
+        response.raise_for_status()
 
 
 def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
@@ -154,3 +176,62 @@ def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
     assert payload[0]["source"] == "dummy"
     assert payload[0]["level"] == "info"
     assert isinstance(payload[0]["@timestamp"], (int, float))
+
+
+def test_out_azure_logs_ingestion_batches_by_compressed_size_and_timeout():
+    service = Service("out_azure_logs_ingestion_batching.yaml")
+    service.start()
+    configure_http_response(status_code=200, body={"status": "received"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    service.service.wait_for_http_endpoint(
+        f"http://127.0.0.1:{service.flb_listener_port}/health",
+        timeout=10,
+        interval=0.25,
+    )
+
+    messages = [
+        f"{index:02d}-"
+        "4f2f8db8-e337-4d2f-9cb2-17008f6de8ce-"
+        "ab8cc998-1ed2-46df-8728-b87681522731-"
+        f"{index * 7919:08x}"
+        for index in range(10)
+    ]
+
+    service.send_log(messages[0])
+    time.sleep(1.5)
+    assert service.data_requests() == []
+
+    for message in messages[1:]:
+        service.send_log(message)
+
+    first_batch = service.service.wait_for_condition(
+        lambda: service.data_requests()[0] if service.data_requests() else None,
+        timeout=10,
+        interval=0.25,
+        description="a compressed-size Azure Logs Ingestion batch",
+    )
+
+    assert 1 < len(first_batch["json"]) < len(messages)
+    assert first_batch["headers"].get("Content-Encoding") == "gzip"
+    assert int(first_batch["headers"]["Content-Length"]) <= 175
+
+    requests_seen = service.service.wait_for_condition(
+        lambda: service.data_requests()
+        if sum(len(request["json"]) for request in service.data_requests()) == len(messages)
+        else None,
+        timeout=10,
+        interval=0.25,
+        description="the timed-out partial Azure Logs Ingestion batch",
+    )
+    service.stop()
+
+    received_messages = [
+        record["message"]
+        for request in requests_seen
+        for record in request["json"]
+    ]
+    assert received_messages == messages

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1,5 +1,7 @@
 import logging
+import math
 import os
+import re
 import shutil
 import tempfile
 import time
@@ -129,6 +131,23 @@ class Service:
             if request["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
         ]
 
+    def batch_preparations(self):
+        with open(self.service.flb.log_file, "r", encoding="utf-8") as log_file:
+            matches = re.findall(
+                r"prepared buffered batch records=(\d+) bytes=(\d+) "
+                r"gzip_operations=(\d+)",
+                log_file.read(),
+            )
+
+        return [
+            {
+                "records": int(record_count),
+                "bytes": int(request_size),
+                "gzip_operations": int(gzip_operations),
+            }
+            for record_count, request_size, gzip_operations in matches
+        ]
+
     def send_log(self, message):
         response = requests.post(
             f"http://127.0.0.1:{self.flb_listener_port}/azure_logs_ingestion",
@@ -193,13 +212,14 @@ def test_out_azure_logs_ingestion_batches_by_compressed_size_and_timeout():
         interval=0.25,
     )
 
-    messages = [
+    messages = ["underfilled"]
+    messages.extend(
         f"{index:02d}-"
         "4f2f8db8-e337-4d2f-9cb2-17008f6de8ce-"
         "ab8cc998-1ed2-46df-8728-b87681522731-"
         f"{index * 7919:08x}"
-        for index in range(10)
-    ]
+        for index in range(30)
+    )
 
     service.send_log(messages[0])
     time.sleep(1.5)
@@ -217,21 +237,93 @@ def test_out_azure_logs_ingestion_batches_by_compressed_size_and_timeout():
 
     assert 1 < len(first_batch["json"]) < len(messages)
     assert first_batch["headers"].get("Content-Encoding") == "gzip"
-    assert int(first_batch["headers"]["Content-Length"]) <= 175
+    assert 122 <= int(first_batch["headers"]["Content-Length"]) <= 175
 
-    requests_seen = service.service.wait_for_condition(
+    service.service.wait_for_condition(
         lambda: service.data_requests()
         if sum(len(request["json"]) for request in service.data_requests()) == len(messages)
         else None,
         timeout=10,
         interval=0.25,
+        description="the full Azure Logs Ingestion batches",
+    )
+
+    request_count = len(service.data_requests())
+    timeout_message = "timeout-partial-batch"
+    service.send_log(timeout_message)
+    time.sleep(1.5)
+    assert len(service.data_requests()) == request_count
+
+    requests_seen = service.service.wait_for_condition(
+        lambda: service.data_requests()
+        if sum(len(request["json"]) for request in service.data_requests()) ==
+        len(messages) + 1
+        else None,
+        timeout=10,
+        interval=0.25,
         description="the timed-out partial Azure Logs Ingestion batch",
     )
+
+    observed_ratios = [
+        len(request["decoded_data"].encode("utf-8")) /
+        int(request["headers"]["Content-Length"])
+        for request in requests_seen
+    ]
+    expected_ratio = observed_ratios[0]
+    for observed_ratio in observed_ratios[1:]:
+        expected_ratio = expected_ratio * 0.75 + observed_ratio * 0.25
+
+    def compression_ratio_metric():
+        response = requests.get(
+            f"http://127.0.0.1:{service.flb.http_monitoring_port}"
+            "/api/v2/metrics/prometheus",
+            timeout=5,
+        )
+        response.raise_for_status()
+        match = re.search(
+            r'fluentbit_azure_logs_ingestion_compression_ratio'
+            r'\{[^}]*name="azure_logs_ingestion\.0"[^}]*\}\s+([0-9.eE+-]+)',
+            response.text,
+        )
+        if match is None:
+            return None
+
+        ratio = float(match.group(1))
+        return ratio if math.isclose(ratio, expected_ratio, rel_tol=1e-6) else None
+
+    compression_ratio = service.service.wait_for_condition(
+        compression_ratio_metric,
+        timeout=5,
+        interval=0.25,
+        description="the Azure Logs Ingestion compression ratio metric",
+    )
+    assert compression_ratio > 1
+
+    batch_preparations = service.batch_preparations()
     service.stop()
+
+    full_batches = [
+        preparation
+        for preparation in batch_preparations
+        if preparation["bytes"] >= 122
+    ]
+    assert len(full_batches) >= 3
+    assert all(preparation["bytes"] <= 175 for preparation in full_batches)
+    assert 130 <= (
+        sum(preparation["bytes"] for preparation in full_batches) /
+        len(full_batches)
+    ) <= 166
+    assert (
+        sum(preparation["gzip_operations"] for preparation in full_batches) /
+        len(full_batches)
+    ) < 2
+    assert len(batch_preparations) == len(requests_seen)
+    assert batch_preparations[-1]["bytes"] < 122
+    assert batch_preparations[-1]["records"] == 1
 
     received_messages = [
         record["message"]
         for request in requests_seen
         for record in request["json"]
     ]
-    assert received_messages == messages
+    assert received_messages == messages + [timeout_message]


### PR DESCRIPTION
Azure Logs Ingestion currently sends each engine chunk immediately, which can produce many undersized requests. This change adds opt-in buffering that targets efficient compressed request sizes and postpones underfilled batches for up to 30 seconds.

Buffering is disabled by default to preserve existing behavior. Set `buffering_enabled on` to enable it. Buffered requests use `min_batch_size` (default 200 KiB) and `max_batch_size` (default 1 MiB), and the selector targets 90% of the interval between them. With the defaults, the target is 941.6 KiB. An unexpired batch waits until it reaches the configured minimum, and the configured maximum remains a hard wire-size ceiling except when one record is larger by itself.

Pending records are staged durably in plugin-local fstore files so engine chunks can be acknowledged without losing delayed data. Batch construction measures the actual gzip payload, splits only at record boundaries, preserves FIFO order across restart, and retries staged data without rebuilding the source chunk. It learns the observed compression ratio instead of assuming one, projects the next record-boundary candidate directly, and reuses an accepted gzip probe for transmission. Stable workloads therefore normally require one gzip operation per emitted request; the integration scenario asserts an average below two. When compression is disabled, sizing follows the uncompressed wire payload and performs no gzip operations.

### Warnings

Buffered delivery is strictly FIFO. A jumbo log record that exceeds `max_batch_size` is sent alone; if that record fails to send, it remains at the head of the durable queue and blocks all following records indefinitely. Only corrupt fstore data—not repeated delivery failure—is treated as poison and removed.

The plugin exports two metrics:

- `fluentbit_azure_logs_ingestion_compression_ratio`: adaptive average of uncompressed JSON bytes divided by gzip bytes, where `4.0` means 4:1 compression.
- `fluentbit_azure_logs_ingestion_gzip_operations_total`: cumulative number of gzip operations attempted in buffered and immediate modes.

### fstore precedents

This follows established local-buffering patterns in other output plugins:

- `out_s3`: `s3_store_buffer_put()` appends formatted chunks to active fstore files before multipart upload.
- `out_gcs`: `gcs_store_buffer_put()` persists formatted output payloads before deferred upload.
- `out_azure_blob`: `azure_blob_store_buffer_put()` buffers chunks for the append-blob upload path.
- `out_azure_kusto`: when `buffering_enabled` is set, `azure_kusto_store_buffer_put()` writes chunks to fstore before ingestion.

`out_calyptia` also uses fstore, but only for session state rather than buffering incoming chunks, so it is not a direct precedent for this change.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change

  `cmake --build build -j8`

  `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py -q` (2 passed)

- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

  Valgrind is unavailable on macOS. The focused scenarios passed under strict macOS Leaks with `LEAKS=1 LEAKS_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py -q` (2 passed).

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature

The new settings include config-map descriptions. User-facing documentation lives in the separate Fluent Bit documentation repository.

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.